### PR TITLE
Only date of oath can be changed now (Fix #1843)

### DIFF
--- a/EPlast/EPlast.BLL/DTO/ActiveMembership/UserMembershipDatesDTO.cs
+++ b/EPlast/EPlast.BLL/DTO/ActiveMembership/UserMembershipDatesDTO.cs
@@ -1,67 +1,13 @@
 ﻿using System;
-using EPlast.Resources;
 
 namespace EPlast.BLL.DTO.ActiveMembership
 {
     public class UserMembershipDatesDTO
     {
-        private DateTime _dateEntry;
-        private DateTime _dateOath;
-        private DateTime _dateEnd;
-
         public string UserId { get; set; }
         public int Id { get; set; }
-
-        public DateTime DateEntry
-        {
-            get => _dateEntry;
-            set
-            {
-                if (value == default)
-                {
-                    _dateEntry = value;
-                    return;
-                }
-                if (value < AllowedDates.LowLimitDate)
-                    throw new ArgumentException($"The entry date cannot be earlier than {AllowedDates.LowLimitDate}");
-                _dateEntry = value;
-            }
-        }
-
-        public DateTime DateOath
-        {
-            get => _dateOath;
-            set
-            {
-                if (value == default)
-                {
-                    _dateOath = value;
-                    return;
-                }
-                if (value < AllowedDates.LowLimitDate || value < _dateEntry)
-                    throw new ArgumentException($"The oath date cannot be earlier than {AllowedDates.LowLimitDate}, " +
-                                                $"and remember entry date < oath date < end date ");
-                _dateOath = value;
-            }
-        }
-
-        public DateTime DateEnd
-        {
-            get => _dateEnd;
-            set
-            {
-                if (value == default)
-                {
-                    _dateEnd = value;
-                    return;
-                }
-                if (value < AllowedDates.LowLimitDate || value < _dateOath || value < _dateEntry)
-                    throw new ArgumentException($"The end date cannot be earlier than {AllowedDates.LowLimitDate}, " +
-                                                $"and remember entry date < oath date < end date ");
-                _dateEnd = value;
-            }
-        }
-
-       
+        public DateTime DateEntry { get; set; }
+        public DateTime DateOath { get; set; }
+        public DateTime DateEnd { get; set; }
     }
 }

--- a/EPlast/EPlast.BLL/DTO/ActiveMembership/UserOathDateDTO.cs
+++ b/EPlast/EPlast.BLL/DTO/ActiveMembership/UserOathDateDTO.cs
@@ -1,0 +1,32 @@
+﻿using EPlast.Resources;
+using System;
+
+namespace EPlast.BLL.DTO.ActiveMembership
+{
+    public class UserOathDateDTO
+    {
+        
+        private DateTime _dateOath;
+
+        public string UserId { get; set; }
+        public int Id { get; set; }
+
+
+        public DateTime DateOath
+        {
+            get => _dateOath;
+            set
+            {
+                if (value == default)
+                {
+                    _dateOath = value;
+                    return;
+                }
+                if (value < AllowedDates.LowLimitDate)
+                    throw new ArgumentException($"The oath date cannot be earlier than {AllowedDates.LowLimitDate}");
+                _dateOath = value;
+            }
+        }
+
+    }
+}

--- a/EPlast/EPlast.BLL/Interfaces/ActiveMembership/IUserDatesService.cs
+++ b/EPlast/EPlast.BLL/Interfaces/ActiveMembership/IUserDatesService.cs
@@ -23,7 +23,7 @@ namespace EPlast.BLL.Interfaces.ActiveMembership
         /// </summary>
         /// <param name="userMembershipDatesDTO"> userMembershipDatesDTO</param>
         /// <returns>bool if changing is successful</returns>
-        public Task<bool> ChangeUserOathDateAsync(UserOathDateDTO userMembershipDatesDTO);
+        public Task<bool> ChangeUserOathDateAsync(UserOathDateDTO userOathDateDTO);
 
         /// <summary>
         /// Returns boolean, if dates is correct and they was added to DB return true, else false

--- a/EPlast/EPlast.BLL/Interfaces/ActiveMembership/IUserDatesService.cs
+++ b/EPlast/EPlast.BLL/Interfaces/ActiveMembership/IUserDatesService.cs
@@ -23,7 +23,7 @@ namespace EPlast.BLL.Interfaces.ActiveMembership
         /// </summary>
         /// <param name="userMembershipDatesDTO"> userMembershipDatesDTO</param>
         /// <returns>bool if changing is successful</returns>
-        public Task<bool> ChangeUserMembershipDatesAsync(UserMembershipDatesDTO userMembershipDatesDTO);
+        public Task<bool> ChangeUserOathDateAsync(UserOathDateDTO userMembershipDatesDTO);
 
         /// <summary>
         /// Returns boolean, if dates is correct and they was added to DB return true, else false

--- a/EPlast/EPlast.BLL/Services/ActiveMembership/UserDatesService.cs
+++ b/EPlast/EPlast.BLL/Services/ActiveMembership/UserDatesService.cs
@@ -21,23 +21,24 @@ namespace EPlast.BLL.Services.ActiveMembership
             _userManagerService = userManagerService;
         }
 
-        public async Task<bool> ChangeUserMembershipDatesAsync(UserMembershipDatesDTO userMembershipDatesDTO)
+        public async Task<bool> ChangeUserOathDateAsync(UserOathDateDTO userOathDateDTO)
         {
             bool isChanged = false;
-            var userDto = await _userManagerService.FindByIdAsync(userMembershipDatesDTO.UserId);
+            var userDto = await _userManagerService.FindByIdAsync(userOathDateDTO.UserId);
             if (userDto != null)
             {
                 UserMembershipDates userMembershipDates = await _repoWrapper.UserMembershipDates.GetFirstOrDefaultAsync(umd => umd.UserId == userDto.Id);
-                if(userMembershipDates != null)
+                if (userMembershipDates != null)
                 {
-                    userMembershipDates.DateEntry = userMembershipDatesDTO.DateEntry;
-                    userMembershipDates.DateOath = userMembershipDatesDTO.DateOath;
-                    userMembershipDates.DateEnd = userMembershipDatesDTO.DateEnd;
-                    _repoWrapper.UserMembershipDates.Update(userMembershipDates);
-                    await _repoWrapper.SaveAsync();
-                    isChanged = true;
+                    var dateOathIsLowerDateEnd = userMembershipDates.DateEnd == default || userMembershipDates.DateEnd > userOathDateDTO.DateOath;
+                    if (userMembershipDates.DateEntry <= userOathDateDTO.DateOath && dateOathIsLowerDateEnd)
+                    {
+                        userMembershipDates.DateOath = userOathDateDTO.DateOath;
+                        _repoWrapper.UserMembershipDates.Update(userMembershipDates);
+                        await _repoWrapper.SaveAsync();
+                        isChanged = true;
+                    }
                 }
-
             }
             return isChanged;
         }
@@ -61,10 +62,10 @@ namespace EPlast.BLL.Services.ActiveMembership
         {
             var userDto = await _userManagerService.FindByIdAsync(userId);
 
-            if(userDto != null)
+            if (userDto != null)
             {
                 UserMembershipDates userMembershipDates = await _repoWrapper.UserMembershipDates.GetFirstOrDefaultAsync(umd => umd.UserId == userId);
-                
+
                 if (userMembershipDates != null)
                 {
                     return _mapper.Map<UserMembershipDatesDTO>(userMembershipDates);
@@ -78,11 +79,11 @@ namespace EPlast.BLL.Services.ActiveMembership
             var userDto = await _userManagerService.FindByIdAsync(userId);
             if (userDto != null)
             {
-                UserMembershipDates userMembershipDates = new UserMembershipDates() 
+                UserMembershipDates userMembershipDates = new UserMembershipDates()
                 {
-                    UserId = userId, 
+                    UserId = userId,
                     DateEntry = default,
-                    DateOath = default, 
+                    DateOath = default,
                     DateEnd = default
                 };
 

--- a/EPlast/EPlast.BLL/Services/Admin/AdminService.cs
+++ b/EPlast/EPlast.BLL/Services/Admin/AdminService.cs
@@ -103,6 +103,7 @@ namespace EPlast.BLL.Services
             {
                 membershipDates.DateEnd = DateTime.Now;
                 _repoWrapper.UserMembershipDates.Update(membershipDates);
+                await _repoWrapper.SaveAsync();
             }
 
             await _userManager.AddToRoleAsync(user, Roles.FormerPlastMember);

--- a/EPlast/EPlast.BLL/Services/Admin/AdminService.cs
+++ b/EPlast/EPlast.BLL/Services/Admin/AdminService.cs
@@ -98,6 +98,13 @@ namespace EPlast.BLL.Services
                 await _sectorAdministrationService.RemoveAdministratorAsync(sectorAdmin.Id);
             }
 
+            var membershipDates = await _repoWrapper.UserMembershipDates.GetFirstOrDefaultAsync(m => m.UserId == userId);
+            if (membershipDates != null)
+            {
+                membershipDates.DateEnd = DateTime.Now;
+                _repoWrapper.UserMembershipDates.Update(membershipDates);
+            }
+
             await _userManager.AddToRoleAsync(user, Roles.FormerPlastMember);
         }
 
@@ -280,15 +287,18 @@ namespace EPlast.BLL.Services
         {
             UserMembershipDates userMembershipDates = await _repoWrapper.UserMembershipDates
                            .GetFirstOrDefaultAsync(umd => umd.UserId == userId);
+            var user = await _userManager.FindByIdAsync(userId);
+            var roles = await _userManager.GetRolesAsync(user);
             var cityMember = await _repoWrapper.CityMembers
                  .GetFirstOrDefaultAsync(u => u.UserId == userId, m => m.Include(u => u.User));
-            if (role == Roles.Supporter && cityMember.IsApproved)
+            if (role == Roles.Supporter && cityMember.IsApproved && userMembershipDates.DateEntry == default)
             {
                 userMembershipDates.DateEntry = DateTime.Now;
             }
-            else if (role != Roles.PlastMember)
+            //This user is former member, and we change his role to registered, that's why we reset his EndDate
+            else if (role == Roles.RegisteredUser && roles.Count == 0)
             {
-                userMembershipDates.DateEntry = default;
+                userMembershipDates.DateEnd = default;
             }
             else
             {

--- a/EPlast/EPlast.Tests/Controllers/ActiveMembershipControllerTests.cs
+++ b/EPlast/EPlast.Tests/Controllers/ActiveMembershipControllerTests.cs
@@ -111,12 +111,12 @@ namespace EPlast.Tests.Controllers
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>()))
                 .ReturnsAsync(new List<string>() { Roles.Admin });
             _plastDegreeService.Setup(cs => cs.AddPlastDegreeForUserAsync(It.IsAny<UserPlastDegreePostDTO>()))
-                .ReturnsAsync(successfulAdded);               
+                .ReturnsAsync(successfulAdded);
 
             ActiveMembershipController activeMembershipController = _activeMembershipController;
 
             //Act
-            var result = await activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = degreeId, UserId = userId});
+            var result = await activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = degreeId, UserId = userId });
 
             //Assert
             Assert.IsInstanceOf<CreatedResult>(result);
@@ -137,9 +137,9 @@ namespace EPlast.Tests.Controllers
             _userService.Setup(x => x.GetUserAsync(It.IsAny<string>()))
                 .ReturnsAsync(_user);
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>()))
-                .ReturnsAsync(new List<string>() { Roles.CityHead,Roles.CityHeadDeputy});
+                .ReturnsAsync(new List<string>() { Roles.CityHead, Roles.CityHeadDeputy });
             _plastDegreeService.Setup(cs => cs.AddPlastDegreeForUserAsync(It.IsAny<UserPlastDegreePostDTO>()))
-                .ReturnsAsync(successfulAdded); 
+                .ReturnsAsync(successfulAdded);
             _userService.Setup(x => x.IsUserSameCity(_user, _user)).Returns(true);
 
             ActiveMembershipController activeMembershipController = _activeMembershipController;
@@ -158,7 +158,7 @@ namespace EPlast.Tests.Controllers
             bool successfulAdded = false;
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = _userId });
             _userService.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(_user);
-            _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.CityHeadDeputy});
+            _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.CityHeadDeputy });
             _plastDegreeService.Setup(cs => cs.AddPlastDegreeForUserAsync(It.IsAny<UserPlastDegreePostDTO>())).ReturnsAsync(successfulAdded);
             _plastDegreeService.Setup(ps => ps.CheckDegreeAsync(It.IsAny<int>(), It.IsAny<List<string>>())).ReturnsAsync(true);
             _userService.Setup(x => x.IsUserSameCity(_user, _user)).Returns(true);
@@ -255,7 +255,7 @@ namespace EPlast.Tests.Controllers
             _userManager.Verify();
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase("2")]
         public async Task GetUserDates_Valid_ReturnsOK(string id)
         {
@@ -289,49 +289,72 @@ namespace EPlast.Tests.Controllers
         }
 
         [Test]
-        public async Task ChangeUserDates_Valid_Test()
+        public async Task ChangeUserOathDate_ReturnOK()
         {
             //Arrange
             bool successfulChangedDates = true;
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = _userId });
             _userService.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(_user);
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.Admin });
-            _userDatesService.Setup(cs => cs.ChangeUserMembershipDatesAsync(It.IsAny<UserMembershipDatesDTO>()))
+            _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.Admin });
+            _userDatesService.Setup(cs => cs.ChangeUserOathDateAsync(It.IsAny<UserOathDateDTO>()))
                              .ReturnsAsync(successfulChangedDates);
 
             ActiveMembershipController activeMembershipController = _activeMembershipController;
 
             //Act
-            var result = await activeMembershipController.ChangeUserDates(new UserMembershipDatesDTO());
+            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
 
             //Assert
             Assert.IsInstanceOf<OkObjectResult>(result);
             Assert.NotNull(((OkObjectResult)result).Value);
-            Assert.IsInstanceOf<UserMembershipDatesDTO>(((OkObjectResult)result).Value);
+            Assert.IsInstanceOf<UserOathDateDTO>(((OkObjectResult)result).Value);
         }
 
         [Test]
-        public async Task ChangeUserDates_InValid_Test()
+        public async Task ChangeUserOathDate_ReturnBadRequest()
         {
             //Arrange
             bool successfulChangedDates = false;
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = _userId });
             _userService.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(_user);
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.Admin });
-            _userDatesService.Setup(cs => cs.ChangeUserMembershipDatesAsync(It.IsAny<UserMembershipDatesDTO>()))
+            _userDatesService.Setup(cs => cs.ChangeUserOathDateAsync(It.IsAny<UserOathDateDTO>()))
                              .ReturnsAsync(successfulChangedDates);
 
             ActiveMembershipController activeMembershipController = _activeMembershipController;
 
             //Act
-            var result = await activeMembershipController.ChangeUserDates(new UserMembershipDatesDTO());
+            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
 
             //Assert
             Assert.IsInstanceOf<BadRequestResult>(result);
         }
 
+
         [Test]
-        public async Task ChangeUserDates_403Forbidden()
+        public async Task ChangeUserOathDate_NoAccess_Return403Forbidden()
+        {
+            //Arrange
+            bool successfulChangedDates = false;
+            _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = _userId });
+            _userService.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(_user);
+            _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.PlastMember });
+            _userDatesService.Setup(cs => cs.ChangeUserOathDateAsync(It.IsAny<UserOathDateDTO>()))
+                             .ReturnsAsync(successfulChangedDates);
+            ActiveMembershipController activeMembershipController = _activeMembershipController;
+            var expected = StatusCodes.Status403Forbidden;
+
+            //Act
+            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
+            var actual = (result as StatusCodeResult).StatusCode;
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public async Task ChangeUserOathDate_Return403Forbidden()
         {
             //Arrange
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = _userId });
@@ -342,7 +365,7 @@ namespace EPlast.Tests.Controllers
             var expected = StatusCodes.Status403Forbidden;
 
             // Act
-            var result = await activeMembershipController.ChangeUserDates(new UserMembershipDatesDTO());
+            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
             var actual = (result as StatusCodeResult).StatusCode;
 
             // Assert

--- a/EPlast/EPlast.Tests/Controllers/ActiveMembershipControllerTests.cs
+++ b/EPlast/EPlast.Tests/Controllers/ActiveMembershipControllerTests.cs
@@ -48,10 +48,8 @@ namespace EPlast.Tests.Controllers
             //Arrange
             _plastDegreeService.Setup(cs => cs.GetDergeesAsync()).ReturnsAsync(new List<PlastDegreeDTO>());
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.GetAllDergees();
+            var result = await _activeMembershipController.GetAllDergees();
             var resultValue = (result as OkObjectResult).Value;
 
             //Assert
@@ -67,10 +65,8 @@ namespace EPlast.Tests.Controllers
             //Arrange
             _accessLevelService.Setup(m => m.GetUserAccessLevelsAsync(It.IsAny<string>())).ReturnsAsync(new List<string>());
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.GetAccessLevel(id);
+            var result = await _activeMembershipController.GetAccessLevel(id);
             var resultValue = (result as OkObjectResult).Value;
 
             //Assert
@@ -86,10 +82,8 @@ namespace EPlast.Tests.Controllers
             //Arrange
             _plastDegreeService.Setup(cs => cs.GetUserPlastDegreeAsync(It.IsAny<string>())).ReturnsAsync(new UserPlastDegreeDTO());
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.GetUserDegree(id);
+            var result = await _activeMembershipController.GetUserDegree(id);
             var resultValue = (result as OkObjectResult).Value;
 
             //Assert
@@ -113,10 +107,8 @@ namespace EPlast.Tests.Controllers
             _plastDegreeService.Setup(cs => cs.AddPlastDegreeForUserAsync(It.IsAny<UserPlastDegreePostDTO>()))
                 .ReturnsAsync(successfulAdded);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = degreeId, UserId = userId });
+            var result = await _activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = degreeId, UserId = userId });
 
             //Assert
             Assert.IsInstanceOf<CreatedResult>(result);
@@ -142,10 +134,8 @@ namespace EPlast.Tests.Controllers
                 .ReturnsAsync(successfulAdded);
             _userService.Setup(x => x.IsUserSameCity(_user, _user)).Returns(true);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = degreeId, UserId = _userId });
+            var result = await _activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = degreeId, UserId = _userId });
 
             //Assert
             Assert.IsInstanceOf<StatusCodeResult>(result);
@@ -162,10 +152,9 @@ namespace EPlast.Tests.Controllers
             _plastDegreeService.Setup(cs => cs.AddPlastDegreeForUserAsync(It.IsAny<UserPlastDegreePostDTO>())).ReturnsAsync(successfulAdded);
             _plastDegreeService.Setup(ps => ps.CheckDegreeAsync(It.IsAny<int>(), It.IsAny<List<string>>())).ReturnsAsync(true);
             _userService.Setup(x => x.IsUserSameCity(_user, _user)).Returns(true);
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
 
             //Act
-            var result = await activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = id });
+            var result = await _activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = id });
 
             //Assert
             Assert.IsInstanceOf<CreatedResult>(result);
@@ -186,12 +175,10 @@ namespace EPlast.Tests.Controllers
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = userId });
             _userService.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(user);
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>());
-
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
             var expected = StatusCodes.Status403Forbidden;
 
             // Act
-            var result = await activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = id, UserId = userId });
+            var result = await _activeMembershipController.AddPlastDegreeForUser(new UserPlastDegreePostDTO() { PlastDegreeId = id, UserId = userId });
             var actual = (result as StatusCodeResult).StatusCode;
 
             // Assert
@@ -210,10 +197,8 @@ namespace EPlast.Tests.Controllers
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.Admin });
             _plastDegreeService.Setup(cs => cs.DeletePlastDegreeForUserAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync(successfulDeleted);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.DeletePlastDegreeForUser("", 0);
+            var result = await _activeMembershipController.DeletePlastDegreeForUser("", 0);
 
             //Assert
             Assert.IsInstanceOf<NoContentResult>(result);
@@ -226,10 +211,8 @@ namespace EPlast.Tests.Controllers
             bool successfulDeleted = false;
             _plastDegreeService.Setup(cs => cs.DeletePlastDegreeForUserAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync(successfulDeleted);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.DeletePlastDegreeForUser("", 0);
+            var result = await _activeMembershipController.DeletePlastDegreeForUser("", 0);
 
             //Assert
             Assert.IsInstanceOf<BadRequestResult>(result);
@@ -242,12 +225,10 @@ namespace EPlast.Tests.Controllers
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = _userId });
             _userService.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(_user);
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>());
-
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
             var expected = StatusCodes.Status403Forbidden;
 
             // Act
-            var result = await activeMembershipController.DeletePlastDegreeForUser(_userId, 4);
+            var result = await _activeMembershipController.DeletePlastDegreeForUser(_userId, 4);
             var actual = (result as StatusCodeResult).StatusCode;
 
             // Assert
@@ -262,10 +243,8 @@ namespace EPlast.Tests.Controllers
             //Arrange
             _userDatesService.Setup(cs => cs.GetUserMembershipDatesAsync(It.IsAny<string>())).ReturnsAsync(new UserMembershipDatesDTO());
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.GetUserDates(id);
+            var result = await _activeMembershipController.GetUserDates(id);
 
             //Assert
             Assert.IsInstanceOf<OkObjectResult>(result);
@@ -279,10 +258,8 @@ namespace EPlast.Tests.Controllers
             //Arrange
             _userDatesService.Setup(cs => cs.GetUserMembershipDatesAsync(It.IsAny<string>())).ThrowsAsync(new InvalidOperationException());
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.GetUserDates(null);
+            var result = await _activeMembershipController.GetUserDates(null);
 
             //Assert
             Assert.IsInstanceOf<BadRequestObjectResult>(result);
@@ -300,10 +277,8 @@ namespace EPlast.Tests.Controllers
             _userDatesService.Setup(cs => cs.ChangeUserOathDateAsync(It.IsAny<UserOathDateDTO>()))
                              .ReturnsAsync(successfulChangedDates);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
+            var result = await _activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
 
             //Assert
             Assert.IsInstanceOf<OkObjectResult>(result);
@@ -322,10 +297,8 @@ namespace EPlast.Tests.Controllers
             _userDatesService.Setup(cs => cs.ChangeUserOathDateAsync(It.IsAny<UserOathDateDTO>()))
                              .ReturnsAsync(successfulChangedDates);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
+            var result = await _activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
 
             //Assert
             Assert.IsInstanceOf<BadRequestResult>(result);
@@ -342,11 +315,10 @@ namespace EPlast.Tests.Controllers
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.PlastMember });
             _userDatesService.Setup(cs => cs.ChangeUserOathDateAsync(It.IsAny<UserOathDateDTO>()))
                              .ReturnsAsync(successfulChangedDates);
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
             var expected = StatusCodes.Status403Forbidden;
 
             //Act
-            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
+            var result = await _activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
             var actual = (result as StatusCodeResult).StatusCode;
 
             //Assert
@@ -360,12 +332,10 @@ namespace EPlast.Tests.Controllers
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User() { Id = _userId });
             _userService.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(_user);
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>());
-
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
             var expected = StatusCodes.Status403Forbidden;
 
             // Act
-            var result = await activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
+            var result = await _activeMembershipController.ChangeUserOathDateAsync(new UserOathDateDTO());
             var actual = (result as StatusCodeResult).StatusCode;
 
             // Assert
@@ -382,10 +352,8 @@ namespace EPlast.Tests.Controllers
             _userDatesService.Setup(cs => cs.AddDateEntryAsync(It.IsAny<string>()))
                              .ReturnsAsync(successfulInitedDates);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.InitializeUserDates("2");
+            var result = await _activeMembershipController.InitializeUserDates("2");
 
             //Assert
             Assert.IsInstanceOf<OkObjectResult>(result);
@@ -401,10 +369,8 @@ namespace EPlast.Tests.Controllers
             _userDatesService.Setup(cs => cs.AddDateEntryAsync(It.IsAny<string>()))
                              .ReturnsAsync(successfulInitedDates);
 
-            ActiveMembershipController activeMembershipController = _activeMembershipController;
-
             //Act
-            var result = await activeMembershipController.InitializeUserDates("");
+            var result = await _activeMembershipController.InitializeUserDates("");
 
             //Assert
             Assert.IsInstanceOf<BadRequestResult>(result);

--- a/EPlast/EPlast.Tests/Services/ActiveMembership/UserDatesServiceTests.cs
+++ b/EPlast/EPlast.Tests/Services/ActiveMembership/UserDatesServiceTests.cs
@@ -46,7 +46,7 @@ namespace EPlast.Tests.Services.ActiveMembership
             UserDatesService userDatesService = _userDatesService;
 
             //Act
-            var result = await userDatesService.ChangeUserMembershipDatesAsync(new UserMembershipDatesDTO() {UserId = " " });
+            var result = await userDatesService.ChangeUserOathDateAsync(new UserOathDateDTO() {UserId = " " });
             //Assert
             Assert.IsTrue(result);
 
@@ -65,7 +65,7 @@ namespace EPlast.Tests.Services.ActiveMembership
             UserDatesService userDatesService = _userDatesService;
 
             //Act
-            var result = await userDatesService.ChangeUserMembershipDatesAsync(new UserMembershipDatesDTO() { UserId = " " });
+            var result = await userDatesService.ChangeUserOathDateAsync(new UserOathDateDTO() { UserId = " " });
             //Assert
             Assert.IsFalse(result);
             _userManagerService.Verify(f => f.FindByIdAsync(It.IsAny<string>()));
@@ -83,7 +83,7 @@ namespace EPlast.Tests.Services.ActiveMembership
             UserDatesService userDatesService = _userDatesService;
 
             //Act
-            var result = await userDatesService.ChangeUserMembershipDatesAsync(new UserMembershipDatesDTO() { UserId = " " });
+            var result = await userDatesService.ChangeUserOathDateAsync(new UserOathDateDTO() { UserId = " " });
             //Assert
             Assert.IsFalse(result);
             _userManagerService.Verify(f => f.FindByIdAsync(It.IsAny<string>()));

--- a/EPlast/EPlast.Tests/Services/Admin/AdminServiceTests.cs
+++ b/EPlast/EPlast.Tests/Services/Admin/AdminServiceTests.cs
@@ -345,6 +345,43 @@ namespace EPlast.Tests.Services
             _repoWrapper.Verify();
         }
 
+        [TestCase("userId")]
+        public async Task ChangeCurrentRoleAsync_AddRegistered_CaseFormerMember_ReturnsCorrectAsync(string userId)
+        {
+            // Arrange
+            var registeredUser = Roles.RegisteredUser;
+            var admin = Roles.Admin;
+            var interested = Roles.Interested;
+
+            _userManager
+                .Setup(x => x.FindByIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(new User());
+            _userManager
+                .Setup(x => x.GetRolesAsync(It.IsAny<User>()))
+                .ReturnsAsync(new List<string>() {});
+            _userManager
+                .Setup(x => x.RemoveFromRoleAsync(It.IsAny<User>(), registeredUser));
+
+            _repoWrapper
+                .Setup(x => x.UserMembershipDates.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<UserMembershipDates, bool>>>(),
+                    It.IsAny<Func<IQueryable<UserMembershipDates>,
+                        IIncludableQueryable<UserMembershipDates, object>>>()))
+                .ReturnsAsync(new UserMembershipDates() { DateEntry = default });
+            _repoWrapper
+                .Setup(x => x.CityMembers.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<CityMembers, bool>>>(),
+                    It.IsAny<Func<IQueryable<CityMembers>,
+                        IIncludableQueryable<CityMembers, object>>>())).ReturnsAsync(new CityMembers() { IsApproved = true });
+            _userManager
+                .Setup(x => x.AddToRoleAsync(It.IsAny<User>(), admin));
+
+            // Act
+            await service.ChangeCurrentRoleAsync(userId, registeredUser);
+
+            // Assert
+            _userManager.Verify();
+            _repoWrapper.Verify();
+        }
+
         [Test]
         public async Task ChangeCurrentRoleAsync_AddInterested_ReturnsCorrectAsync()
         {

--- a/EPlast/EPlast.Tests/Services/Admin/AdminServiceTests.cs
+++ b/EPlast/EPlast.Tests/Services/Admin/AdminServiceTests.cs
@@ -351,7 +351,6 @@ namespace EPlast.Tests.Services
             // Arrange
             var registeredUser = Roles.RegisteredUser;
             var admin = Roles.Admin;
-            var interested = Roles.Interested;
 
             _userManager
                 .Setup(x => x.FindByIdAsync(It.IsAny<string>()))

--- a/EPlast/EPlast.WebApi/Controllers/ActiveMembershipController.cs
+++ b/EPlast/EPlast.WebApi/Controllers/ActiveMembershipController.cs
@@ -138,17 +138,23 @@ namespace EPlast.WebApi.Controllers
 
         [Authorize(AuthenticationSchemes = "Bearer", Roles = Roles.HeadsAndHeadDeputiesAndAdmin)]
         [HttpPost("dates")]
-        public async Task<IActionResult> ChangeUserDates(UserMembershipDatesDTO userMembershipDatesDTO)
+        public async Task<IActionResult> ChangeUserOathDateAsync(UserOathDateDTO userOathDateDTO)
         {
-            if (!await HasAccessAsync(userMembershipDatesDTO.UserId))
+            var focusUser = await _userManager.FindByIdAsync(userOathDateDTO.UserId);
+            var roles = await _userManager.GetRolesAsync(focusUser);
+            //If user is registered or former member, then we can not change oath date!
+            if(roles.Contains(Roles.RegisteredUser) || roles.Count == 0)
             {
                 return StatusCode(StatusCodes.Status403Forbidden);
             }
-            if (await _userDatesService.ChangeUserMembershipDatesAsync(userMembershipDatesDTO))
+            if (!await HasAccessAsync(userOathDateDTO.UserId))
             {
-                return Ok(userMembershipDatesDTO);
+                return StatusCode(StatusCodes.Status403Forbidden);
             }
-
+            if (await _userDatesService.ChangeUserOathDateAsync(userOathDateDTO))
+            {
+                return Ok(userOathDateDTO);
+            }
             return BadRequest();
         }
 

--- a/EPlast/EPlast.WebApi/Controllers/ActiveMembershipController.cs
+++ b/EPlast/EPlast.WebApi/Controllers/ActiveMembershipController.cs
@@ -143,11 +143,7 @@ namespace EPlast.WebApi.Controllers
             var focusUser = await _userManager.FindByIdAsync(userOathDateDTO.UserId);
             var roles = await _userManager.GetRolesAsync(focusUser);
             //If user is registered or former member, then we can not change oath date!
-            if(roles.Contains(Roles.RegisteredUser) || roles.Count == 0)
-            {
-                return StatusCode(StatusCodes.Status403Forbidden);
-            }
-            if (!await HasAccessAsync(userOathDateDTO.UserId))
+            if(roles.Contains(Roles.RegisteredUser) || roles.Count == 0 || !await HasAccessAsync(userOathDateDTO.UserId))
             {
                 return StatusCode(StatusCodes.Status403Forbidden);
             }


### PR DESCRIPTION
We can change only the oath date now.
If user became former member when API will automatically set end date as  current date.
If user change role from former to registered when end date will be reset.

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
