### PR TITLE
Add VSCode IDE configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,13 @@ _pkginfo.txt
 # but keep track of directories ending in .cache
 !?*.[Cc]ache/
 
+# Visual Studio Code launch configuration folder
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
 # Others
 ClientBin/
 ~$*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "adrianwilczynski.user-secrets",
+    "eamodio.gitlens",
+    "fernandoescolar.vscode-solution-explorer",
+    "formulahendry.dotnet-test-explorer",
+    "github.vscode-pull-request-github",
+    "ms-dotnettools.csharp"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (web)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/EPlast/EPlast.WebApi/bin/Debug/netcoreapp3.1/EPlast.WebApi.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/EPlast/EPlast.WebApi",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "^\\s*Now listening on:\\s+(https?://\\S+)",
+        "uriFormat": "%s/swagger"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "https://localhost:44350;http://localhost:52780"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      },
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "omnisharp.enableImportCompletion": true,
+  "omnisharp.enableRoslynAnalyzers": true,
+  "omnisharp.organizeImportsOnFormat": true,
+  "gitlens.codeLens.scopes": [
+    "document",
+    "containers",
+    "blocks"
+  ],
+  "dotnet-test-explorer.addProblems": false,
+  "dotnet-test-explorer.enableTelemetry": false,
+  "dotnet-test-explorer.runInParallel": true,
+  "dotnet-test-explorer.treeMode": "full",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,43 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/EPlast/EPlast.WebApi/EPlast.WebApi.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/EPlast/EPlast.WebApi/EPlast.WebApi.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/EPlast/EPlast.WebApi/EPlast.WebApi.csproj",
+        "--urls",
+        "https://localhost:44350;http://localhost:52780"
+      ],
+      "problemMatcher": "$msCompile",
+    }
+  ]
+}


### PR DESCRIPTION
**Important.**
This PR does not affect project in any way.
It only enables launch profiles to use in VS Code IDE.

## Code reviewers

- [ ] @petromonka

### Second Level Review

- [ ] @Goven112
- [ ] @bkondrat
- [ ] @Omeliukh-Nazar

## Summary of issue

Some users (like me) have performance issues using VS Community 2022 due to old PC configuration or running the project on not high-end laptop. So lightweight IDE is a good option for them. For example VS Code, which is also used on our EPlast-Client project as main IDE.

Currently VS Code is not configured to build, watch nor launch the project. This PR addresses that.

## Summary of change

- Added `tasks.json` configuration to build the project (works like `dotnet build --project ./EPlast/EPlast.WebApi/`)
- Added `tasks.json` configuration to watch the project (works like `dotnet watch run --project ./EPlast/EPlast.WebApi/ --urls ...`)
- Added `launch.json` configuration to run project (pre-launch task `build`, then `dotnet run --urls ...`)
- Added `extensions.json` file with recommended VS Code extensions to use with this project
- Added `settings.json` to set up best-fitted VS Code extensions settings and VS Code IDE settings
- Updated `.gitignore` to exclude any other content in `.vscode/` folder (like some extensions cache, etc.)

## Testing approach

PR does not affect the project, no testing required.

## How to use VS Code to develop and debug EPlast backend project

User manual (temporarily in russian language, sorry for that): [Google Drive](https://drive.google.com/file/d/1sUPiNapVc3DHzLqrs3_zTQkPyUUFcA6g/view?usp=sharing).

Переклад на українську мову буде зроблено незабаром, та інструкція (після аппруву) буде додана до Вікі цього репозиторію.

## CHECK LIST

- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
