### PR TITLE
Fix compiler warnings (except for obsolete cityservice)

### DIFF
--- a/EPlast/EPlast.BLL/Handlers/DecisionHandlers/GetDecisionsForTableHandler.cs
+++ b/EPlast/EPlast.BLL/Handlers/DecisionHandlers/GetDecisionsForTableHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using EPlast.DataAccess.Repositories;
@@ -25,7 +25,7 @@ namespace EPlast.BLL.Handlers.DecisionHandlers
 
         public async Task<IEnumerable<DecisionTableObject>>Handle(GetDecisionsForTableQuery request, CancellationToken cancellationToken)
         {
-            return _repositoryWrapper.Decesion.GetDecisions(request.SearchData, request.Page, request.PageSize);
+            return await _repositoryWrapper.Decesion.GetDecisions(request.SearchData, request.Page, request.PageSize);
         }
     }
 }

--- a/EPlast/EPlast.BLL/Handlers/DecisionHandlers/GetDecisionsForTableHandler.cs
+++ b/EPlast/EPlast.BLL/Handlers/DecisionHandlers/GetDecisionsForTableHandler.cs
@@ -1,16 +1,16 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using EPlast.BLL.DTO;
+using EPlast.BLL.Queries.Decision;
+using EPlast.DataAccess.Entities.Decision;
 using EPlast.DataAccess.Repositories;
 using MediatR;
-using EPlast.BLL.Queries.Decision;
-using EPlast.BLL.DTO;
-using AutoMapper;
-using System.Threading.Tasks;
-using System.Threading;
 using Microsoft.EntityFrameworkCore;
-using System.Linq;
-using EPlast.DataAccess.Entities.Decision;
 
 namespace EPlast.BLL.Handlers.DecisionHandlers
 {

--- a/EPlast/EPlast.BLL/Services/City/CityParticipantsService.cs
+++ b/EPlast/EPlast.BLL/Services/City/CityParticipantsService.cs
@@ -1,18 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
 using EPlast.BLL.DTO.City;
 using EPlast.BLL.Interfaces;
 using EPlast.BLL.Interfaces.Admin;
 using EPlast.BLL.Interfaces.City;
-using EPlast.BLL.Services.Interfaces;
 using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories;
 using EPlast.Resources;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace EPlast.BLL.Services.City
 {

--- a/EPlast/EPlast.BLL/Services/City/CityParticipantsService.cs
+++ b/EPlast/EPlast.BLL/Services/City/CityParticipantsService.cs
@@ -23,7 +23,6 @@ namespace EPlast.BLL.Services.City
         private readonly IMapper _mapper;
         private readonly IRepositoryWrapper _repositoryWrapper;
         private readonly ICityService _cityService;
-        private readonly IUserManagerService _userManagerService;
         private readonly UserManager<User> _userManager;
 
         public CityParticipantsService(IRepositoryWrapper repositoryWrapper,

--- a/EPlast/EPlast.BLL/Services/GoverningBodies/GoverningBodiesService.cs
+++ b/EPlast/EPlast.BLL/Services/GoverningBodies/GoverningBodiesService.cs
@@ -1,3 +1,7 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
 using AutoMapper.Internal;
 using EPlast.BLL.DTO;
@@ -10,10 +14,6 @@ using EPlast.DataAccess.Entities.GoverningBody;
 using EPlast.DataAccess.Repositories;
 using EPlast.Resources;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace EPlast.BLL.Services.GoverningBodies
 {

--- a/EPlast/EPlast.BLL/Services/GoverningBodies/GoverningBodiesService.cs
+++ b/EPlast/EPlast.BLL/Services/GoverningBodies/GoverningBodiesService.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using AutoMapper.Internal;
 using EPlast.BLL.DTO;
 using EPlast.BLL.DTO.GoverningBody;
@@ -65,7 +65,7 @@ namespace EPlast.BLL.Services.GoverningBodies
 
         private Task<Organization> CreateGoverningBodyAsync(GoverningBodyDTO governingBody)
         {
-            return Task.FromResult(_mapper.Map<GoverningBodyDTO, Organization>(governingBody));
+            return Task.Run(() => _mapper.Map<GoverningBodyDTO, Organization>(governingBody));
         }
 
         public async Task<int> EditAsync(GoverningBodyDTO governingBody)

--- a/EPlast/EPlast.BLL/Services/GoverningBodies/Sector/SectorService.cs
+++ b/EPlast/EPlast.BLL/Services/GoverningBodies/Sector/SectorService.cs
@@ -1,3 +1,7 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
 using AutoMapper.Internal;
 using EPlast.BLL.DTO.GoverningBody.Sector;
@@ -8,10 +12,6 @@ using EPlast.DataAccess.Entities.GoverningBody.Sector;
 using EPlast.DataAccess.Repositories;
 using EPlast.Resources;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using GBSector = EPlast.DataAccess.Entities.GoverningBody.Sector.Sector;
 
 namespace EPlast.BLL.Services.GoverningBodies.Sector

--- a/EPlast/EPlast.BLL/Services/GoverningBodies/Sector/SectorService.cs
+++ b/EPlast/EPlast.BLL/Services/GoverningBodies/Sector/SectorService.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using AutoMapper.Internal;
 using EPlast.BLL.DTO.GoverningBody.Sector;
 using EPlast.BLL.Interfaces;
@@ -90,7 +90,7 @@ namespace EPlast.BLL.Services.GoverningBodies.Sector
 
         private Task<GBSector> CreateSectorAsync(SectorDTO sector)
         {
-            return Task.FromResult(_mapper.Map<SectorDTO, GBSector>(sector));
+            return Task.Run(() => _mapper.Map<SectorDTO, GBSector>(sector));
         }
 
         public async Task<IEnumerable<SectorDTO>> GetSectorsByGoverningBodyAsync(int governingBodyId)

--- a/EPlast/EPlast.BLL/Services/Region/RegionAnnualReportService.cs
+++ b/EPlast/EPlast.BLL/Services/Region/RegionAnnualReportService.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using EPlast.BLL.DTO.Region;
 using EPlast.BLL.Interfaces.Region;
 using EPlast.DataAccess.Entities;
@@ -207,7 +207,7 @@ namespace EPlast.BLL.Services.Region
 
         public async Task<IEnumerable<RegionAnnualReportDTO>> GetAllRegionsReportsAsync()
         {
-            return _mapper.Map<IEnumerable<RegionAnnualReport>, IEnumerable<RegionAnnualReportDTO>>(await Task.FromResult(_repositoryWrapper.RegionAnnualReports.FindAll().ToList()));
+            return _mapper.Map<IEnumerable<RegionAnnualReport>, IEnumerable<RegionAnnualReportDTO>>(await Task.Run(() => _repositoryWrapper.RegionAnnualReports.FindAll().ToList()));
         }
 
         public async Task<IEnumerable<RegionAnnualReportTableObject>> GetAllRegionsReportsAsync(User user, bool isAdmin, string searchedData, int page, int pageSize, int sortKey, bool auth)

--- a/EPlast/EPlast.BLL/Services/Region/RegionAnnualReportService.cs
+++ b/EPlast/EPlast.BLL/Services/Region/RegionAnnualReportService.cs
@@ -1,13 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
 using EPlast.BLL.DTO.Region;
 using EPlast.BLL.Interfaces.Region;
 using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace EPlast.BLL.Services.Region
 {

--- a/EPlast/EPlast.DataAccess/EPlastDBContext.cs
+++ b/EPlast/EPlast.DataAccess/EPlastDBContext.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using EPlast.DataAccess.Entities;
+﻿using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Entities.AboutBase;
 using EPlast.DataAccess.Entities.Blank;
 using EPlast.DataAccess.Entities.Decision;
@@ -15,13 +14,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace EPlast.DataAccess
 {
-    public class EPlastDBContext : IdentityDbContext<IdentityUser, IdentityRole, string>
+    public class EPlastDBContext : IdentityDbContext<User, IdentityRole, string>
     {
         public EPlastDBContext(DbContextOptions<EPlastDBContext> options) : base(options)
         {
         }
 
-        public DbSet<User> Users { get; set; }
         public DbSet<UserProfile> UserProfiles { get; set; }
         public DbSet<Nationality> Nationalities { get; set; }
         public DbSet<Religion> Religions { get; set; }

--- a/EPlast/EPlast.DataAccess/EPlastDBContext.cs
+++ b/EPlast/EPlast.DataAccess/EPlastDBContext.cs
@@ -16,52 +16,104 @@ namespace EPlast.DataAccess
 {
     public class EPlastDBContext : IdentityDbContext<User, IdentityRole, string>
     {
-        public EPlastDBContext(DbContextOptions<EPlastDBContext> options) : base(options)
-        {
-        }
+        public EPlastDBContext(DbContextOptions<EPlastDBContext> options) : base(options) { }
 
-        public DbSet<UserProfile> UserProfiles { get; set; }
-        public DbSet<Nationality> Nationalities { get; set; }
-        public DbSet<Religion> Religions { get; set; }
-        public DbSet<Education> Educations { get; set; }
-        public DbSet<Degree> Degrees { get; set; }
-        public DbSet<Gender> Genders { get; set; }
-        public DbSet<UpuDegree> UpuDegrees { get; set; }
-        public DbSet<Work> Works { get; set; }
-        public DbSet<ConfirmedUser> ConfirmedUsers { get; set; }
+        public DbSet<AchievementDocuments> AchievementDocuments { get; set; }
+        public DbSet<AdminType> AdminTypes { get; set; }
+        public DbSet<AnnualReport> AnnualReports { get; set; }
+        public DbSet<AnnualReportTableObject> AnnualReportTableObjects { get; set; }
         public DbSet<Approver> Approvers { get; set; }
+        public DbSet<BlankBiographyDocuments> BlankBiographyDocuments { get; set; }
+        public DbSet<City> Cities { get; set; }
+        public DbSet<CityAdministration> CityAdministrations { get; set; }
+        public DbSet<CityDocuments> CityDocuments { get; set; }
+        public DbSet<CityDocumentType> CityDocumentTypes { get; set; }
+        public DbSet<CityLegalStatus> CityLegalStatuses { get; set; }
+        public DbSet<CityMembers> CityMembers { get; set; }
+        public DbSet<CityObject> CityObjects { get; set; }
+        public DbSet<Club> Clubs { get; set; }
+        public DbSet<ClubAdministration> ClubAdministrations { get; set; }
+        public DbSet<ClubAnnualReport> ClubAnnualReports { get; set; }
+        public DbSet<ClubAnnualReportTableObject> ClubAnnualReportTableObjects { get; set; }
+        public DbSet<ClubDocuments> ClubDocuments { get; set; }
+        public DbSet<ClubDocumentType> ClubDocumentTypes { get; set; }
+        public DbSet<ClubLegalStatus> ClubLegalStatuses { get; set; }
+        public DbSet<ClubMemberHistory> ClubMemberHistory { get; set; }
+        public DbSet<ClubMembers> ClubMembers { get; set; }
+        public DbSet<ClubReportAdmins> ClubReportAdmins { get; set; }
+        public DbSet<ClubReportCities> ClubReportCities { get; set; }
+        public DbSet<ClubReportMember> ClubReportMember { get; set; }
+        public DbSet<ClubReportPlastDegrees> ClubReportPlastDegrees { get; set; }
+        public DbSet<ConfirmedUser> ConfirmedUsers { get; set; }
+        public DbSet<Decesion> Decesions { get; set; }
+        public DbSet<DecesionTarget> DecesionTargets { get; set; }
+        public DbSet<DecisionTableObject> DecisionTableObject { get; set; }
+        public DbSet<Degree> Degrees { get; set; }
+        public DbSet<Distinction> Distinctions { get; set; }
+        public DbSet<DocumentTemplate> DocumentTemplates { get; set; }
+        public DbSet<Education> Educations { get; set; }
+        public DbSet<EducatorsStaff> KVs { get; set; }
+        public DbSet<EducatorsStaffTableObject> EducatorsStaffTableObjects { get; set; }
+        public DbSet<EducatorsStaffTypes> KVTypes { get; set; }
         public DbSet<Event> Events { get; set; }
-        public DbSet<Gallary> Gallarys { get; set; }
-        public DbSet<EventGallary> EventGallarys { get; set; }
-        public DbSet<ParticipantStatus> ParticipantStatuses { get; set; }
-        public DbSet<Participant> Participants { get; set; }
-        public DbSet<EventCategory> EventCategories { get; set; }
-        public DbSet<EventType> EventTypes { get; set; }
-        public DbSet<EventCategoryType> EventCategoryTypes { get; set; }
-        public DbSet<EventStatus> EventStatuses { get; set; }
         public DbSet<EventAdministration> EventAdministration { get; set; }
         public DbSet<EventAdministrationType> EventAdministrationType { get; set; }
-        public DbSet<UserTableObject> UserTableObjects { get; set; }
-        public DbSet<RegionObject> RegionObjects { get; set; }
-        public DbSet<CityObject> CityObjects { get; set; }
-        public DbSet<RegionNamesObject> RegionNamesObjects { get; set; }
-        public DbSet<Section> Sections { get; set; }
-        public DbSet<Subsection> Subsections { get; set; }
-        public DbSet<SubsectionPictures> SubsectionsPictures { get; set; }
-        public DbSet<Pictures> Pictures { get; set; }
-        public DbSet<AnnualReportTableObject> AnnualReportTableObjects { get; set; }
-        public DbSet<ClubAnnualReportTableObject> ClubAnnualReportTableObjects { get; set; }
-        public DbSet<RegionAnnualReportTableObject> RegionAnnualReportTableObjects { get; set; }
-        public DbSet<UserDistinctionsTableObject> UserDistinctionsTableObject { get; set; }
-        public DbSet<MethodicDocumentTableObject> MethodicDocumentTableObjects { get; set; }
-        public DbSet<DecisionTableObject> DecisionTableObject { get; set; }
-        public DbSet<RegionMembersInfoTableObject> RegionMembersInfoTableObjects { get; set; }
+        public DbSet<EventCategory> EventCategories { get; set; }
+        public DbSet<EventCategoryType> EventCategoryTypes { get; set; }
+        public DbSet<EventGallary> EventGallarys { get; set; }
+        public DbSet<EventSection> EventSection { get; set; }
+        public DbSet<EventStatus> EventStatuses { get; set; }
+        public DbSet<EventType> EventTypes { get; set; }
+        public DbSet<ExtractFromUPUDocuments> ExtractFromUPUDocuments { get; set; }
+        public DbSet<Gallary> Gallarys { get; set; }
+        public DbSet<Gender> Genders { get; set; }
+        public DbSet<GoverningBodyAdministration> GoverningBodyAdministrations { get; set; }
         public DbSet<GoverningBodyAnnouncement> GoverningBodyAnnouncement { get; set; }
         public DbSet<GoverningBodyAnnouncementImage> GoverningBodyAnnouncementImages { get; set; }
+        public DbSet<GoverningBodyDocuments> GoverningBodyDocuments { get; set; }
+        public DbSet<GoverningBodyDocumentType> GoverningBodyDocumentTypes { get; set; }
+        public DbSet<MembersStatistic> MembersStatistics { get; set; }
+        public DbSet<MethodicDocument> MethodicDocuments { get; set; }
+        public DbSet<MethodicDocumentTableObject> MethodicDocumentTableObjects { get; set; }
+        public DbSet<Nationality> Nationalities { get; set; }
+        public DbSet<NotificationType> NotificationTypes { get; set; }
+        public DbSet<Organization> Organization { get; set; }
+        public DbSet<Participant> Participants { get; set; }
+        public DbSet<ParticipantStatus> ParticipantStatuses { get; set; }
+        public DbSet<Pictures> Pictures { get; set; }
+        public DbSet<PlastDegree> PlastDegrees { get; set; }
+        public DbSet<Precaution> Precautions { get; set; }
+        public DbSet<Region> Regions { get; set; }
+        public DbSet<RegionAdministration> RegionAdministrations { get; set; }
+        public DbSet<RegionAnnualReport> RegionAnnualReports { get; set; }
+        public DbSet<RegionAnnualReportTableObject> RegionAnnualReportTableObjects { get; set; }
+        public DbSet<RegionDocuments> RegionDocs { get; set; }
+        public DbSet<RegionFollowers> RegionFollowers { get; set; }
+        public DbSet<RegionMembersInfoTableObject> RegionMembersInfoTableObjects { get; set; }
+        public DbSet<RegionNamesObject> RegionNamesObjects { get; set; }
+        public DbSet<RegionObject> RegionObjects { get; set; }
+        public DbSet<Religion> Religions { get; set; }
+        public DbSet<Section> Sections { get; set; }
+        public DbSet<Sector> GoverningBodySectors { get; set; }
+        public DbSet<SectorAdministration> GoverningBodySectorAdministrations { get; set; }
+        public DbSet<SectorDocuments> GoverningBodySectorDocuments { get; set; }
+        public DbSet<SectorDocumentType> GoverningBodySectorDocumentTypes { get; set; }
+        public DbSet<Subsection> Subsections { get; set; }
+        public DbSet<SubsectionPictures> SubsectionsPictures { get; set; }
         public DbSet<Terms> Terms { get; set; }
+        public DbSet<UpuDegree> UpuDegrees { get; set; }
+        public DbSet<UserDistinction> UserDistinctions { get; set; }
+        public DbSet<UserDistinctionsTableObject> UserDistinctionsTableObject { get; set; }
+        public DbSet<UserMembershipDates> UserMembershipDates { get; set; }
+        public DbSet<UserNotification> UserNotifications { get; set; }
+        public DbSet<UserPlastDegree> UserPlastDegrees { get; set; }
+        public DbSet<UserPrecaution> UserPrecautions { get; set; }
+        public DbSet<UserPrecautionsTableObject> UserPrecautionsTableObject { get; set; }
+        public DbSet<UserProfile> UserProfiles { get; set; }
         public DbSet<UserRenewal> UserRenewals { get; set; }
         public DbSet<UserRenewalsTableObject> UserRenewalsTableObjects { get; set; }
-        public DbSet<EducatorsStaffTableObject> EducatorsStaffTableObjects { get; set; }
+        public DbSet<UserTableObject> UserTableObjects { get; set; }
+        public DbSet<Work> Works { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -271,65 +323,5 @@ namespace EPlast.DataAccess
                 annualReport.HasOne(a => a.Club);
             });
         }
-        public DbSet<RegionAnnualReport> RegionAnnualReports { get; set; }
-        public DbSet<DocumentTemplate> DocumentTemplates { get; set; }
-        public DbSet<DecesionTarget> DecesionTargets { get; set; }
-        public DbSet<Decesion> Decesions { get; set; }
-        public DbSet<MethodicDocument> MethodicDocuments { get; set; }
-        public DbSet<AnnualReport> AnnualReports { get; set; }
-        public DbSet<ClubAnnualReport> ClubAnnualReports { get; set; }
-
-        public DbSet<MembersStatistic> MembersStatistics { get; set; }
-
-        public DbSet<Organization> Organization { get; set; }
-        public DbSet<GoverningBodyAdministration> GoverningBodyAdministrations { get; set; }
-        public DbSet<GoverningBodyDocuments> GoverningBodyDocuments { get; set; }
-        public DbSet<GoverningBodyDocumentType> GoverningBodyDocumentTypes { get; set; }
-
-        public DbSet<Sector> GoverningBodySectors { get; set; }
-        public DbSet<SectorAdministration> GoverningBodySectorAdministrations { get; set; }
-        public DbSet<SectorDocuments> GoverningBodySectorDocuments { get; set; }
-        public DbSet<SectorDocumentType> GoverningBodySectorDocumentTypes { get; set; }
-
-        public DbSet<City> Cities { get; set; }
-        public DbSet<CityAdministration> CityAdministrations { get; set; }
-        public DbSet<CityDocuments> CityDocuments { get; set; }
-        public DbSet<CityDocumentType> CityDocumentTypes { get; set; }
-        public DbSet<CityMembers> CityMembers { get; set; }
-
-        public DbSet<AdminType> AdminTypes { get; set; }
-
-        public DbSet<Club> Clubs { get; set; }
-        public DbSet<ClubAdministration> ClubAdministrations { get; set; }
-        public DbSet<ClubDocuments> ClubDocuments { get; set; }
-        public DbSet<ClubDocumentType> ClubDocumentTypes { get; set; }
-        public DbSet<ClubMembers> ClubMembers { get; set; }
-
-        public DbSet<Region> Regions { get; set; }
-        public DbSet<RegionDocuments> RegionDocs { get; set; }
-        public DbSet<RegionAdministration> RegionAdministrations { get; set; }
-        public DbSet<RegionFollowers> RegionFollowers { get; set; }
-        public DbSet<CityLegalStatus> CityLegalStatuses { get; set; }
-        public DbSet<ClubLegalStatus> ClubLegalStatuses { get; set; }
-        public DbSet<UserPlastDegree> UserPlastDegrees { get; set; }
-        public DbSet<UserMembershipDates> UserMembershipDates { get; set; }
-        public DbSet<PlastDegree> PlastDegrees { get; set; }
-        public DbSet<EducatorsStaff> KVs { get; set; }
-        public DbSet<EducatorsStaffTypes> KVTypes { get; set; }
-        public DbSet<Precaution> Precautions { get; set; }
-        public DbSet<Distinction> Distinctions { get; set; }
-        public DbSet<UserPrecaution> UserPrecautions { get; set; }
-        public DbSet<UserDistinction> UserDistinctions { get; set; }
-        public DbSet<BlankBiographyDocuments> BlankBiographyDocuments { get; set; }
-        public DbSet<NotificationType> NotificationTypes { get; set; }
-        public DbSet<UserNotification> UserNotifications { get; set; }
-        public DbSet<AchievementDocuments> AchievementDocuments { get; set; }
-        public DbSet<ExtractFromUPUDocuments> ExtractFromUPUDocuments { get; set; }
-        public DbSet<EventSection> EventSection { get; set; }
-        public DbSet<ClubReportPlastDegrees> ClubReportPlastDegrees { get; set; }
-        public DbSet<ClubReportMember> ClubReportMember { get; set; }
-        public DbSet<ClubReportAdmins> ClubReportAdmins { get; set; }
-        public DbSet<ClubMemberHistory> ClubMemberHistory { get; set; }
-        public DbSet<ClubReportCities> ClubReportCities { get; set; }
     }
 }

--- a/EPlast/EPlast.DataAccess/Entities/Region/RegionMembersInfoTableObject.cs
+++ b/EPlast/EPlast.DataAccess/Entities/Region/RegionMembersInfoTableObject.cs
@@ -1,11 +1,15 @@
-﻿namespace EPlast.DataAccess.Entities
+namespace EPlast.DataAccess.Entities
 {
     public class RegionMembersInfoTableObject
     {
         public int? Total { get; set; }
+
         public int? CityAnnualReportId { get; set; }
+
         public int? CityId { get; set; }
-        public string? CityName { get; set; }
+
+        public string CityName { get; set; }
+
         public int? ReportStatus { get; set; }
 
         public int? NumberOfSeatsPtashat { get; set; }

--- a/EPlast/EPlast.DataAccess/Repositories/Interfaces/Decision/IDecesion.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Interfaces/Decision/IDecesion.cs
@@ -1,3 +1,4 @@
+﻿using System.Collections.Generic;
 using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Entities.Decision;
 using System.Threading.Tasks;

--- a/EPlast/EPlast.DataAccess/Repositories/Interfaces/Decision/IDecesion.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Interfaces/Decision/IDecesion.cs
@@ -1,11 +1,11 @@
-﻿using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Entities.Decision;
-using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EPlast.DataAccess.Repositories
 {
     public interface IDecesionRepository : IRepositoryBase<Decesion>
     {
-        IEnumerable<DecisionTableObject> GetDecisions(string searchData, int page, int pageSize);
+        Task<IEnumerable<DecisionTableObject>> GetDecisions(string searchData, int page, int pageSize);
     }
 }

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Admin/AdminTypeRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Admin/AdminTypeRepository.cs
@@ -1,10 +1,10 @@
-using EPlast.DataAccess.Entities;
-using EPlast.DataAccess.Repositories.Contracts;
-using Microsoft.EntityFrameworkCore;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Repositories.Contracts;
+using Microsoft.EntityFrameworkCore;
 
 namespace EPlast.DataAccess.Repositories
 {

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Admin/AdminTypeRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Admin/AdminTypeRepository.cs
@@ -1,4 +1,4 @@
-﻿using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Contracts;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -22,9 +22,8 @@ namespace EPlast.DataAccess.Repositories
 
         public async Task<Tuple<IEnumerable<UserTableObject>, int>> GetUserTableObjects(int pageNum, int pageSize, string tab, string regions, string cities, string clubs, string degrees, int sortKey, string searchData, string filterRoles="", string andClubs = null)
         {
-          //  andClubs = "Степові відьми";
-            var items = EPlastDBContext.Set<UserTableObject>().FromSqlRaw("dbo.usp_GetUserInfo @PageIndex = {0}, @PageSize = {1}, @tab = {2}, @filterRegion = {3}, " +
-                "@filterCity = {4}, @filterClub = {5}, @filterDegree = {6}, @sort={7}, @filterRoles={8}, @searchData = {9}, @andClub = {10}", pageNum, pageSize, tab, regions, cities, clubs, degrees, sortKey, filterRoles, searchData, andClubs);
+            var items = await Task.Run(() => EPlastDBContext.Set<UserTableObject>().FromSqlRaw("dbo.usp_GetUserInfo @PageIndex = {0}, @PageSize = {1}, @tab = {2}, @filterRegion = {3}, " +
+                "@filterCity = {4}, @filterClub = {5}, @filterDegree = {6}, @sort={7}, @filterRoles={8}, @searchData = {9}, @andClub = {10}", pageNum, pageSize, tab, regions, cities, clubs, degrees, sortKey, filterRoles, searchData, andClubs));
 
             var num = items.Select(u => u.Count).ToList();
             int rowCount = num.Count>0? num[0]:0;

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/AnnualReport/AnnualReportsRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/AnnualReport/AnnualReportsRepository.cs
@@ -1,8 +1,8 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Contracts;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace EPlast.DataAccess.Repositories
 {

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/AnnualReport/AnnualReportsRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/AnnualReport/AnnualReportsRepository.cs
@@ -1,4 +1,4 @@
-﻿using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Contracts;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
@@ -15,9 +15,9 @@ namespace EPlast.DataAccess.Repositories
 
         public async Task<IEnumerable<AnnualReportTableObject>> GetAnnualReportsAsync(string userId, bool isAdmin, string searchdata, int page, int pageSize, int sortKey, bool auth)
         {
-            var items = EPlastDBContext.Set<AnnualReportTableObject>().FromSqlRaw(
+            var items = await Task.Run(() => EPlastDBContext.Set<AnnualReportTableObject>().FromSqlRaw(
                 "dbo.getCityAnnualReportsInfo @userId={0}, @AdminRole={1}, @searchData = {2}, @PageIndex ={3}, @PageSize={4}, @sort={5}, @auth={6}",
-                userId, isAdmin ? 1 : 0, searchdata, page, pageSize, sortKey, auth ? 1 : 0);
+                userId, isAdmin ? 1 : 0, searchdata, page, pageSize, sortKey, auth ? 1 : 0));
             return items;
         }
     }

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/City/CityRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/City/CityRepository.cs
@@ -1,10 +1,10 @@
-using EPlast.DataAccess.Entities;
-using EPlast.DataAccess.Repositories.Contracts;
-using Microsoft.EntityFrameworkCore;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Repositories.Contracts;
+using Microsoft.EntityFrameworkCore;
 
 namespace EPlast.DataAccess.Repositories
 {

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/City/CityRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/City/CityRepository.cs
@@ -1,4 +1,4 @@
-﻿using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Contracts;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -17,7 +17,7 @@ namespace EPlast.DataAccess.Repositories
 
         public async Task<Tuple<IEnumerable<CityObject>, int>> GetCitiesObjects(int pageNum, int pageSize, string searchData, bool isArchive)
         {
-            var items = EPlastDBContext.Set<CityObject>().FromSqlRaw("dbo.sp_GetCities @PageIndex = {0}, @PageSize = {1}, @IsArhivated = {2}, @searchData = {3}", pageNum, pageSize, isArchive, searchData);
+            var items = await Task.Run(() => EPlastDBContext.Set<CityObject>().FromSqlRaw("dbo.sp_GetCities @PageIndex = {0}, @PageSize = {1}, @IsArhivated = {2}, @searchData = {3}", pageNum, pageSize, isArchive, searchData));
             var num = items.Select(u => u.Count).ToList();
             int rowCount = num.Count > 0 ? num[0] : 0;
             return new Tuple<IEnumerable<CityObject>, int>(items, rowCount);

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Club/ClubAnnualReportRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Club/ClubAnnualReportRepository.cs
@@ -1,7 +1,7 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Interfaces.Club;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
 namespace EPlast.DataAccess.Repositories.Realizations.Club

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Club/ClubAnnualReportRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Club/ClubAnnualReportRepository.cs
@@ -1,4 +1,4 @@
-﻿using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Interfaces.Club;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -15,9 +15,9 @@ namespace EPlast.DataAccess.Repositories.Realizations.Club
         public async Task<IEnumerable<ClubAnnualReportTableObject>> GetClubAnnualReportsAsync(string userId,
             bool isAdmin, string searchdata, int page, int pageSize, int sortKey, bool auth)
         {
-            var items = EPlastDBContext.Set<ClubAnnualReportTableObject>().FromSqlRaw(
+            var items = await Task.Run(() => EPlastDBContext.Set<ClubAnnualReportTableObject>().FromSqlRaw(
                 "dbo.getClubAnnualReportsInfo @UserId={0}, @AdminRole={1}, @searchData = {2}, @PageIndex ={3}, @PageSize={4}, @sort={5}, @auth={6}",
-                userId, isAdmin ? 1 : 0, searchdata, page, pageSize, sortKey, auth ? 1 : 0);
+                userId, isAdmin ? 1 : 0, searchdata, page, pageSize, sortKey, auth ? 1 : 0));
             return items;
         }
     }

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Decision/DecesionRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Decision/DecesionRepository.cs
@@ -1,8 +1,8 @@
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Entities.Decision;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
 
 namespace EPlast.DataAccess.Repositories
 {

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Decision/DecesionRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Decision/DecesionRepository.cs
@@ -1,4 +1,5 @@
-﻿using EPlast.DataAccess.Entities;
+using System.Threading.Tasks;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Entities.Decision;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
@@ -11,11 +12,11 @@ namespace EPlast.DataAccess.Repositories
         {
         }
 
-        public IEnumerable<DecisionTableObject> GetDecisions(string searchData, int page, int pageSize)
+        public async Task<IEnumerable<DecisionTableObject>> GetDecisions(string searchData, int page, int pageSize)
         {
-            return EPlastDBContext.Set<DecisionTableObject>().FromSqlRaw(
+            return await Task.Run(() => EPlastDBContext.Set<DecisionTableObject>().FromSqlRaw(
                 "dbo.getDecisionsInfo  @searchData = {0}, @PageIndex = {1}, @PageSize = {2}", searchData, page,
-                pageSize);
+                pageSize));
         }
     }
 }

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionAnnualReportRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionAnnualReportRepository.cs
@@ -1,4 +1,4 @@
-﻿using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Interfaces.Region;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
@@ -17,18 +17,18 @@ namespace EPlast.DataAccess.Repositories.Realizations.Region
         public async Task<IEnumerable<RegionAnnualReportTableObject>> GetRegionAnnualReportsAsync(string userId,
             bool isAdmin, string searchdata, int page, int pageSize, int sortKey, bool auth)
         {
-            var items = EPlastDBContext.Set<RegionAnnualReportTableObject>().FromSqlRaw(
+            var items = await Task.Run(() => EPlastDBContext.Set<RegionAnnualReportTableObject>().FromSqlRaw(
                 "dbo.getRegionAnnualReportsInfo @UserId={0}, @AdminRole={1}, @searchData = {2}, @PageIndex ={3}, @PageSize={4}, @sort={5}, @auth={6}",
-                userId, isAdmin ? 1 : 0, searchdata, page, pageSize, sortKey, auth ? 1 : 0);
+                userId, isAdmin ? 1 : 0, searchdata, page, pageSize, sortKey, auth ? 1 : 0));
             return items;
         }
 
         public async Task<IEnumerable<RegionMembersInfoTableObject>> GetRegionMembersInfoAsync(int regionId, int year, bool? getGeneral,
             int? page, int? pageSize)
         {
-            var items = EPlastDBContext.Set<RegionMembersInfoTableObject>().FromSqlRaw(
+            var items = await Task.Run(() => EPlastDBContext.Set<RegionMembersInfoTableObject>().FromSqlRaw(
                 "dbo.GetRegionMembersInfo @regionId={0}, @year={1}, @GetGeneral={2}, @PageIndex ={3}, @PageSize={4}",
-                regionId, year, getGeneral, page, pageSize);
+                regionId, year, getGeneral, page, pageSize));
             return items;
         }
     }

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionAnnualReportRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionAnnualReportRepository.cs
@@ -1,8 +1,8 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Interfaces.Region;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace EPlast.DataAccess.Repositories.Realizations.Region
 {

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionRepository.cs
@@ -1,10 +1,10 @@
-using EPlast.DataAccess.Entities;
-using EPlast.DataAccess.Repositories.Contracts;
-using Microsoft.EntityFrameworkCore;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Repositories.Contracts;
+using Microsoft.EntityFrameworkCore;
 
 namespace EPlast.DataAccess.Repositories
 {

--- a/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionRepository.cs
+++ b/EPlast/EPlast.DataAccess/Repositories/Realizations/Region/RegionRepository.cs
@@ -1,4 +1,4 @@
-﻿using EPlast.DataAccess.Entities;
+using EPlast.DataAccess.Entities;
 using EPlast.DataAccess.Repositories.Contracts;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -16,7 +16,7 @@ namespace EPlast.DataAccess.Repositories
         }
         public async Task<Tuple<IEnumerable<RegionObject>, int>> GetRegionsObjects(int pageNum, int pageSize,  string searchData, bool isArchive)
         {
-            var items = EPlastDBContext.Set<RegionObject>().FromSqlRaw("dbo.sp_GetRegions @PageIndex = {0}, @PageSize = {1}, @IsArhivated = {2}, @searchData = {3}", pageNum, pageSize, isArchive, searchData);
+            var items = await Task.Run(() => EPlastDBContext.Set<RegionObject>().FromSqlRaw("dbo.sp_GetRegions @PageIndex = {0}, @PageSize = {1}, @IsArhivated = {2}, @searchData = {3}", pageNum, pageSize, isArchive, searchData));
             var num = items.Select(u => u.Count).ToList();
             int rowCount = num.Count > 0 ? num[0] : 0;
             return new Tuple<IEnumerable<RegionObject>, int>(items, rowCount);        

--- a/EPlast/EPlast.Tests/Controllers/DecisionsControllerTests.cs
+++ b/EPlast/EPlast.Tests/Controllers/DecisionsControllerTests.cs
@@ -1,7 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
 using AutoMapper;
 using EPlast.BLL;
+using EPlast.BLL.Commands.Decision;
 using EPlast.BLL.DTO;
 using EPlast.BLL.Interfaces.GoverningBodies;
+using EPlast.BLL.Queries.Decision;
 using EPlast.BLL.Services.Interfaces;
 using EPlast.DataAccess.Entities.Decision;
 using EPlast.WebApi.Controllers;
@@ -14,15 +21,6 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
 using Moq;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Principal;
-using System.Threading.Tasks;
-using EPlast.BLL.Queries.Decision;
-using EPlast.BLL.Commands.Decision;
-using System.Threading;
-using EPlast.BLL.ExtensionMethods;
-using EPlast.WebApi.StartupExtensions;
 
 namespace EPlast.Tests.Controllers
 {

--- a/EPlast/EPlast.Tests/Controllers/DecisionsControllerTests.cs
+++ b/EPlast/EPlast.Tests/Controllers/DecisionsControllerTests.cs
@@ -390,9 +390,10 @@ namespace EPlast.Tests.Controllers
                     Text = "Text2"
                 },
             };
-        public async Task<IEnumerable<DecisionTableObject>> FakedDecisionTableObject()
+            
+        public Task<IEnumerable<DecisionTableObject>> FakedDecisionTableObject()
         {
-            return new List<DecisionTableObject>();
+            return Task.FromResult(new List<DecisionTableObject>().AsEnumerable());
         }
     }
 }

--- a/EPlast/EPlast.Tests/Handlers/Decision/GetDecisionsForTableHandlerTest.cs
+++ b/EPlast/EPlast.Tests/Handlers/Decision/GetDecisionsForTableHandlerTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EPlast.BLL.Handlers.DecisionHandlers;
@@ -14,21 +15,22 @@ namespace EPlast.Tests.Handlers.Decision
     {
         private Mock<IRepositoryWrapper> _mockRepoWrapper;
         private GetDecisionsForTableHandler _handler;
+
         [SetUp]
         public void SetUp()
         {
             _mockRepoWrapper = new Mock<IRepositoryWrapper>();
             _handler = new GetDecisionsForTableHandler(_mockRepoWrapper.Object);
         }
+
         [Test]
-        public void GetDecisionsForTable_ReturnsUserDistinctionsTableObject()
+        public void GetDecisionsForTable_ReturnsUserDistinctionsTableObjectAsync()
         {
             //Arrange
-
             _mockRepoWrapper
                 .Setup(x => x.Decesion.GetDecisions(It.IsAny<string>(),
                     It.IsAny<int>(), It.IsAny<int>()))
-                .Returns(new List<DecisionTableObject>());
+                .ReturnsAsync(new List<DecisionTableObject>().AsEnumerable());
 
             //Act
             var result = _handler.Handle(It.IsAny<GetDecisionsForTableQuery>(), It.IsAny<CancellationToken>());

--- a/EPlast/EPlast.Tests/Handlers/Decision/GetDecisionsForTableHandlerTest.cs
+++ b/EPlast/EPlast.Tests/Handlers/Decision/GetDecisionsForTableHandlerTest.cs
@@ -1,12 +1,12 @@
-﻿using EPlast.BLL.Handlers.DecisionHandlers;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EPlast.BLL.Handlers.DecisionHandlers;
 using EPlast.BLL.Queries.Decision;
 using EPlast.DataAccess.Entities.Decision;
 using EPlast.DataAccess.Repositories;
 using Moq;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace EPlast.Tests.Handlers.Decision
 {

--- a/EPlast/EPlast.WebApi/EPlast.WebApi.csproj
+++ b/EPlast/EPlast.WebApi/EPlast.WebApi.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Fix all incorrect async/await usage (review carefully to see changes)
- Fix Razor downgrade warning (Razor in fact is not used in WebApi)
- Removed `DbSet<User> Users` because it was hiding already existing DbSet of Users from IdentityDbContext
- Minor: Removed unused nullable check in `RegionMembersInfoTableObject`
- Minor: Sorted DbSets in `EPlastDbContext` by name, file looks more organized 
- Minor: Sorted `usings` by name (auto-format by IDE) in all affected by PR files

Projects boots up correctly, tests are passed (both NUnit and XUnit).

TODO: In next PR for warnings fix Obsolete warnings will be addressed.

Message to every developer: do not ignore warnings. [Treat ](https://blog.submain.com/treat-warnings-errors/) [Warnings ](https://medium.com/it-dead-inside/why-i-always-treat-warnings-as-errors-5895fb7f8600) [As ](https://stackoverflow.com/questions/57842756/why-should-i-always-enable-compiler-warnings) [Errors](https://dailydotnettips.com/avoid-code-warnings-being-missed-or-ignored-treating-warnings-as-errors-in-visual-studio/).

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
