### PR TITLE
Ignore .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,9 @@ _pkginfo.txt
 # but keep track of directories ending in .cache
 !?*.[Cc]ache/
 
+# Visual Studio Code launch configuration folder
+.vscode/
+
 # Others
 ClientBin/
 ~$*


### PR DESCRIPTION
So files from .vscode folder won't appear on source control screen and won't been accidently commited.