### PR TITLE
[HELP WANTED] Migrate from vs2017-win2016 to windows-2022 environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
   - job: Test
     displayName: Test
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2022'
     steps:
     - task: DotNetCoreCLI@2
       displayName: Restore


### PR DESCRIPTION
`vs2017-win2016` environment is deprecated and will be removed on June 30, 2022.

