### PR TITLE
Dropped SectorAnnouncementImage, SectorAnnouncement, UserPrecautionsT…

### DIFF
--- a/EPlast/EPlast.DataAccess/EPlast.DataAccess.csproj
+++ b/EPlast/EPlast.DataAccess/EPlast.DataAccess.csproj
@@ -39,6 +39,8 @@
     <Compile Remove="Migrations\20210910085423_IncreaseMaxLenghtPlaceOfStudy.Designer.cs" />
     <Compile Remove="Migrations\20210818105200_cityReport.cs" />
     <Compile Remove="Migrations\20210818105200_cityReport.Designer.cs" />
+    <Compile Remove="Migrations\20220606134526_DropTableUserPrecautionsTableObject.cs" />
+    <Compile Remove="Migrations\20220606134526_DropTableUserPrecautionsTableObject.Designer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EPlast/EPlast.DataAccess/EPlastDBContext.cs
+++ b/EPlast/EPlast.DataAccess/EPlastDBContext.cs
@@ -56,7 +56,6 @@ namespace EPlast.DataAccess
         public DbSet<RegionAnnualReportTableObject> RegionAnnualReportTableObjects { get; set; }
         public DbSet<UserDistinctionsTableObject> UserDistinctionsTableObject { get; set; }
         public DbSet<MethodicDocumentTableObject> MethodicDocumentTableObjects { get; set; }
-        public DbSet<UserPrecautionsTableObject> UserPrecautionsTableObject { get; set; }
         public DbSet<DecisionTableObject> DecisionTableObject { get; set; }
         public DbSet<RegionMembersInfoTableObject> RegionMembersInfoTableObjects { get; set; }
         public DbSet<GoverningBodyAnnouncement> GoverningBodyAnnouncement { get; set; }
@@ -75,7 +74,6 @@ namespace EPlast.DataAccess
             modelBuilder.Entity<ClubAnnualReportTableObject>().HasNoKey();
             modelBuilder.Entity<RegionAnnualReportTableObject>().HasNoKey();
             modelBuilder.Entity<UserDistinctionsTableObject>().HasNoKey();
-            modelBuilder.Entity<UserPrecautionsTableObject>().HasNoKey();
             modelBuilder.Entity<DecisionTableObject>().HasNoKey();
             modelBuilder.Entity<RegionMembersInfoTableObject>().HasNoKey();
             modelBuilder.Entity<MethodicDocumentTableObject>().HasNoKey();

--- a/EPlast/EPlast.DataAccess/Migrations/20220606135303_DropTableUserPrecautionsTableObjectAndSectorAnnouncement.Designer.cs
+++ b/EPlast/EPlast.DataAccess/Migrations/20220606135303_DropTableUserPrecautionsTableObjectAndSectorAnnouncement.Designer.cs
@@ -4,14 +4,16 @@ using EPlast.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace EPlast.DataAccess.Migrations
 {
     [DbContext(typeof(EPlastDBContext))]
-    partial class EPlastDBContextModelSnapshot : ModelSnapshot
+    [Migration("20220606135303_DropTableUserPrecautionsTableObjectAndSectorAnnouncement")]
+    partial class DropTableUserPrecautionsTableObjectAndSectorAnnouncement
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EPlast/EPlast.DataAccess/Migrations/20220606135303_DropTableUserPrecautionsTableObjectAndSectorAnnouncement.cs
+++ b/EPlast/EPlast.DataAccess/Migrations/20220606135303_DropTableUserPrecautionsTableObjectAndSectorAnnouncement.cs
@@ -10,9 +10,6 @@ namespace EPlast.DataAccess.Migrations
             migrationBuilder.DropTable(
                 name: "SectorAnnouncementImage");
 
-            //migrationBuilder.DropTable(
-            //    name: "UserPrecautionsTableObject");
-
             migrationBuilder.DropTable(
                 name: "SectorAnnouncement");
         }

--- a/EPlast/EPlast.DataAccess/Migrations/20220606135303_DropTableUserPrecautionsTableObjectAndSectorAnnouncement.cs
+++ b/EPlast/EPlast.DataAccess/Migrations/20220606135303_DropTableUserPrecautionsTableObjectAndSectorAnnouncement.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace EPlast.DataAccess.Migrations
+{
+    public partial class DropTableUserPrecautionsTableObjectAndSectorAnnouncement : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SectorAnnouncementImage");
+
+            //migrationBuilder.DropTable(
+            //    name: "UserPrecautionsTableObject");
+
+            migrationBuilder.DropTable(
+                name: "SectorAnnouncement");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SectorAnnouncement",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SectorId = table.Column<int>(type: "int", nullable: false),
+                    Text = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SectorAnnouncement", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SectorAnnouncement_GoverningBodySectors_SectorId",
+                        column: x => x.SectorId,
+                        principalTable: "GoverningBodySectors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SectorAnnouncement_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserPrecautionsTableObject",
+                columns: table => new
+                {
+                    Count = table.Column<int>(type: "int", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Id = table.Column<int>(type: "int", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    Number = table.Column<int>(type: "int", nullable: false),
+                    PrecautionName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Reason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Reporter = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Total = table.Column<int>(type: "int", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserName = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SectorAnnouncementImage",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ImagePath = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SectorAnnouncementId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SectorAnnouncementImage", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SectorAnnouncementImage_SectorAnnouncement_SectorAnnouncementId",
+                        column: x => x.SectorAnnouncementId,
+                        principalTable: "SectorAnnouncement",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SectorAnnouncement_SectorId",
+                table: "SectorAnnouncement",
+                column: "SectorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SectorAnnouncement_UserId",
+                table: "SectorAnnouncement",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SectorAnnouncementImage_SectorAnnouncementId",
+                table: "SectorAnnouncementImage",
+                column: "SectorAnnouncementId");
+        }
+    }
+}


### PR DESCRIPTION
…ableObject

I changed [EPlastDBContextModelSnapshot] so it would not show SectorAnnouncementImage, SectorAnnouncement, UserPrecautionsTableObject tables. 
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
