### PR TITLE
Fix GBAdmin role removal

### DIFF
--- a/EPlast/EPlast.BLL/Interfaces/GoverningBodies/IGoverningBodyAdministrationService.cs
+++ b/EPlast/EPlast.BLL/Interfaces/GoverningBodies/IGoverningBodyAdministrationService.cs
@@ -52,7 +52,7 @@ namespace EPlast.BLL.Interfaces.GoverningBodies
         /// Removes Administration roles of user in Governing Body
         /// </summary>
         /// <param name="userId">The id of the user</param>
-        Task RemoveAdminRolesByUserIdAsync(string userId);
+        Task RemoveGbAdminRoleAsync(string userId);
 
         Task<bool> CheckRoleNameExistsAsync(string roleName);
     }

--- a/EPlast/EPlast.BLL/Services/FormerMember/FormerMemberAdminService.cs
+++ b/EPlast/EPlast.BLL/Services/FormerMember/FormerMemberAdminService.cs
@@ -1,4 +1,5 @@
-﻿using EPlast.BLL.Interfaces.City;
+﻿using System.Threading.Tasks;
+using EPlast.BLL.Interfaces.City;
 using EPlast.BLL.Interfaces.Club;
 using EPlast.BLL.Interfaces.FormerMember;
 using EPlast.BLL.Interfaces.GoverningBodies;
@@ -6,7 +7,6 @@ using EPlast.BLL.Interfaces.GoverningBodies.Sector;
 using EPlast.BLL.Interfaces.Region;
 using EPlast.DataAccess.Entities;
 using Microsoft.AspNetCore.Identity;
-using System.Threading.Tasks;
 
 namespace EPlast.BLL.Services.FormerMember
 {
@@ -47,7 +47,7 @@ namespace EPlast.BLL.Services.FormerMember
             await _clubParticipants.RemoveAdminRolesByUserIdAsync(userId);
             await _cityParticipants.RemoveAdminRolesByUserIdAsync(userId);
             await _regionAdministrationService.RemoveAdminRolesByUserIdAsync(userId);
-            await _governingBodyAdministrationService.RemoveAdminRolesByUserIdAsync(userId);
+            await _governingBodyAdministrationService.RemoveGbAdminRoleAsync(userId);
             await _sectorAdministrationService.RemoveAdminRolesByUserIdAsync(userId);
         }
     }

--- a/EPlast/EPlast.Tests/Services/FormerMember/FormerMemberAdminServiceTest.cs
+++ b/EPlast/EPlast.Tests/Services/FormerMember/FormerMemberAdminServiceTest.cs
@@ -1,4 +1,6 @@
-﻿using EPlast.BLL.Interfaces.City;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using EPlast.BLL.Interfaces.City;
 using EPlast.BLL.Interfaces.Club;
 using EPlast.BLL.Interfaces.GoverningBodies;
 using EPlast.BLL.Interfaces.GoverningBodies.Sector;
@@ -8,8 +10,6 @@ using EPlast.DataAccess.Entities;
 using Microsoft.AspNetCore.Identity;
 using Moq;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace EPlast.Tests.Services.FormerMember
 {
@@ -58,7 +58,7 @@ namespace EPlast.Tests.Services.FormerMember
             _regionAdministrationService
                 .Setup(x => x.RemoveAdminRolesByUserIdAsync(It.IsAny<string>()));
             _governingBodyAdministrationService
-              .Setup(x => x.RemoveAdminRolesByUserIdAsync(It.IsAny<string>()));
+              .Setup(x => x.RemoveGbAdminRoleAsync(It.IsAny<string>()));
             _sectorAdministrationService
                 .Setup(x => x.RemoveAdminRolesByUserIdAsync(It.IsAny<string>()));
             //Act

--- a/EPlast/EPlast.Tests/Services/GoverningBody/GoverningBodyAdministrationServiceTests.cs
+++ b/EPlast/EPlast.Tests/Services/GoverningBody/GoverningBodyAdministrationServiceTests.cs
@@ -105,8 +105,8 @@ namespace EPlast.Tests.Services.GoverningBody
                        IIncludableQueryable<Organization, object>>>()))
                .ReturnsAsync(GoverningBody);
             _userManager
-                .Setup(x => x.GetRolesAsync(It.IsAny<User>()))
-                .ReturnsAsync(new List<string> { Roles.PlastMember });
+                .Setup(x => x.IsInRoleAsync(It.IsAny<User>(), It.Is<string>(v => v == Roles.PlastMember)))
+                .ReturnsAsync(true);
             _adminTypeService
                 .Setup(a => a.GetAdminTypeByNameAsync(It.IsAny<string>()))
                 .ReturnsAsync(new AdminTypeDto());
@@ -131,8 +131,8 @@ namespace EPlast.Tests.Services.GoverningBody
                         IIncludableQueryable<Organization, object>>>()))
                 .ReturnsAsync(GoverningBody);
             _userManager
-                .Setup(x => x.GetRolesAsync(It.IsAny<User>()))
-                .ReturnsAsync(new List<string> { Roles.PlastMember });
+                .Setup(x => x.IsInRoleAsync(It.IsAny<User>(), It.Is<string>(v => v == Roles.PlastMember)))
+                .ReturnsAsync(true);
             _adminTypeService
                 .Setup(a => a.GetAdminTypeByNameAsync(It.IsAny<string>()))
                 .ReturnsAsync(new AdminTypeDto());
@@ -175,8 +175,8 @@ namespace EPlast.Tests.Services.GoverningBody
                 .Setup(s => s.GoverningBodyAdministration.CreateAsync(GoverningBodyAdmin));
             _userManager.Setup(m => m.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(new User());
             _userManager
-                .Setup(x => x.GetRolesAsync(It.IsAny<User>()))
-                .ReturnsAsync(new List<string> { Roles.PlastMember });
+                .Setup(x => x.IsInRoleAsync(It.IsAny<User>(), It.Is<string>(v => v == Roles.PlastMember)))
+                .ReturnsAsync(true);
             _adminTypeService
                 .Setup(a => a.GetAdminTypeByNameAsync(It.IsAny<string>()))
                 .ReturnsAsync(new AdminTypeDto());
@@ -197,8 +197,8 @@ namespace EPlast.Tests.Services.GoverningBody
                 .Setup(s => s.GoverningBodyAdministration.CreateAsync(GoverningBodyAdmin));
             _userManager.Setup(m => m.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(new User());
             _userManager
-                .Setup(x => x.GetRolesAsync(It.IsAny<User>()))
-                .ReturnsAsync(new List<string> { Roles.PlastMember });
+                .Setup(x => x.IsInRoleAsync(It.IsAny<User>(), It.Is<string>(v => v == Roles.PlastMember)))
+                .ReturnsAsync(true);
             _adminTypeService
                 .Setup(a => a.GetAdminTypeByNameAsync(It.IsAny<string>()))
                 .ReturnsAsync(new AdminTypeDto());
@@ -320,8 +320,8 @@ namespace EPlast.Tests.Services.GoverningBody
                        IIncludableQueryable<Organization, object>>>()))
                .ReturnsAsync(GoverningBody);
             _userManager
-                .Setup(x => x.GetRolesAsync(It.IsAny<User>()))
-                .ReturnsAsync(new List<string> { Roles.PlastMember });
+                .Setup(x => x.IsInRoleAsync(It.IsAny<User>(), It.Is<string>(v => v == Roles.PlastMember)))
+                .ReturnsAsync(true);
             _adminTypeService
                 .Setup(a => a.GetAdminTypeByNameAsync(It.IsAny<string>()))
                 .ReturnsAsync(new AdminTypeDto
@@ -426,7 +426,7 @@ namespace EPlast.Tests.Services.GoverningBody
             var result = _governingBodyAdministrationService.RemoveAdministratorAsync(It.IsAny<int>());
             //Assert
             _repoWrapper.Verify();
-            _userManager.Verify(x => x.RemoveFromRoleAsync(It.IsAny<User>(), It.IsAny<string>()), Times.Exactly(2));
+            _userManager.Verify(x => x.RemoveFromRoleAsync(It.IsAny<User>(), It.IsAny<string>()), Times.Once);
 
             Assert.NotNull(result);
         }
@@ -460,7 +460,7 @@ namespace EPlast.Tests.Services.GoverningBody
                 .Setup(r => r.SaveAsync());
 
             //Act
-            await _governingBodyAdministrationService.RemoveAdminRolesByUserIdAsync(It.IsAny<string>());
+            await _governingBodyAdministrationService.RemoveGbAdminRoleAsync(It.IsAny<string>());
 
             //Assert
             _repoWrapper.Verify();


### PR DESCRIPTION
Була проблема що неможливо було другий раз додати одного юзера до крайового адміна (якщо перший строк закінчився вже).
Також була проблема, що не видалялась роль крайового адміна з таблиці AspNetUserRoles