### PR TITLE
Restore #2703 changes with squash

### DIFF
--- a/EPlast/EPlast.BLL/Services/UserProfiles/UserProfileAccessService.cs
+++ b/EPlast/EPlast.BLL/Services/UserProfiles/UserProfileAccessService.cs
@@ -1,8 +1,9 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using EPlast.BLL.Interfaces.UserProfiles;
 using EPlast.DataAccess.Entities;
 using EPlast.Resources;
 using Microsoft.AspNetCore.Identity;
-using System.Threading.Tasks;
 using DatabaseEntities = EPlast.DataAccess.Entities;
 
 namespace EPlast.BLL.Services.UserProfiles
@@ -20,11 +21,11 @@ namespace EPlast.BLL.Services.UserProfiles
 
         public async Task<bool> CanApproveAsHead(User user, string focusUserId, string role)
         {
-            var roles = await _userManager.GetRolesAsync(user);
+            var currentUserRoles = await _userManager.GetRolesAsync(user);
             var focusUserRoles = await _userManager.GetRolesAsync(await _userManager.FindByIdAsync(focusUserId));
             var currentUser = await _userService.GetUserAsync(user.Id);
             var focusUser = await _userService.GetUserAsync(focusUserId);
-            if (await IsAdminAsync(user) && focusUserRoles.Contains(Roles.Supporter))
+            if (IsUserAdmin(currentUserRoles) && focusUserRoles.Contains(Roles.Supporter))
             {
                 return true;
             }
@@ -32,53 +33,89 @@ namespace EPlast.BLL.Services.UserProfiles
             return role switch
             {
                 Roles.CityHead =>
-                    (roles.Contains(Roles.CityHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City)),
+                    (currentUserRoles.Contains(Roles.CityHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City)) ||
+                    (currentUserRoles.Contains(Roles.OkrugaHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Region)),
                 Roles.KurinHead =>
-                    (roles.Contains(Roles.KurinHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club)),
+                    (currentUserRoles.Contains(Roles.KurinHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club)),
                 _ => false,
             };
         }
 
         public async Task<bool> CanEditUserProfile(User user, string focusUserId)
         {
-            var roles = await _userManager.GetRolesAsync(user);
+            if (user.Id == focusUserId)
+            {
+                return true;
+            }
+
+            var currentUserRoles = await _userManager.GetRolesAsync(user);
             var currentUser = await _userService.GetUserAsync(user.Id);
             var focusUser = await _userService.GetUserAsync(focusUserId);
-            if (await IsAdminAsync(user) || user.Id == focusUserId)
+            if (IsUserAdmin(currentUserRoles))
             {
                 return true;
             }
             return
-                ((roles.Contains(Roles.OkrugaHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Region)) ||
-                ((roles.Contains(Roles.CityHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City)) ||
-                ((roles.Contains(Roles.KurinHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club));
+                ((currentUserRoles.Contains(Roles.OkrugaHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Region)) ||
+                ((currentUserRoles.Contains(Roles.CityHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City)) ||
+                ((currentUserRoles.Contains(Roles.KurinHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club));
         }
-        
+
         public async Task<bool> CanViewFullProfile(User user, string focusUserId)
         {
-            var roles = await _userManager.GetRolesAsync(user);
-            var currentUser = await _userService.GetUserAsync(user.Id);
-            var focusUser = await _userService.GetUserAsync(focusUserId);
-
-            if (user.Id == focusUserId || await IsAdminAsync(user))
+            if (user.Id == focusUserId)
             {
                 return true;
             }
-            if (roles.Contains(Roles.RegisteredUser) || roles.Contains(Roles.Supporter))
+
+            var currentUserRoles = await _userManager.GetRolesAsync(user);
+            var currentUser = await _userService.GetUserAsync(user.Id);
+            var focusUser = await _userService.GetUserAsync(focusUserId);
+            if (IsUserAdmin(currentUserRoles))
+            {
+                return true;
+            }
+
+            if (IsRegionAdmin(currentUserRoles) && _userService.IsUserSameRegion(currentUser, focusUser))
+            {
+                return true;
+            }
+
+            if (IsCityAdmin(currentUserRoles) && _userService.IsUserSameCity(currentUser, focusUser))
+            {
+                return true;
+            }
+
+            if (currentUserRoles.Contains(Roles.RegisteredUser) || currentUserRoles.Contains(Roles.Supporter))
             {
                 return false;
             }
+
             return
-                (_userService.IsUserSameCity(currentUser, focusUser) || _userService.IsUserSameClub(currentUser, focusUser)) ||
-                ((roles.Contains(Roles.OkrugaHead) || roles.Contains(Roles.OkrugaHeadDeputy)) && _userService.IsUserSameRegion(currentUser, focusUser));
+                _userService.IsUserSameCity(currentUser, focusUser) ||
+                 _userService.IsUserSameClub(currentUser, focusUser);
         }
 
-        private async Task<bool> IsAdminAsync(User user)
+        private bool IsRegionAdmin(IList<string> userRoles)
         {
-            var roles = await _userManager.GetRolesAsync(user);
-            return roles.Contains(Roles.Admin) || 
-                roles.Contains(Roles.GoverningBodyHead) || 
-                roles.Contains(Roles.GoverningBodyAdmin);
+            return userRoles.Contains(Roles.OkrugaHead)
+                   || userRoles.Contains(Roles.OkrugaHeadDeputy)
+                   || userRoles.Contains(Roles.OkrugaReferentUPS)
+                   || userRoles.Contains(Roles.OkrugaReferentUSP)
+                   || userRoles.Contains(Roles.OkrugaReferentOfActiveMembership);
+        }
+
+        private bool IsCityAdmin(IList<string> userRoles)
+        {
+            return userRoles.Contains(Roles.CityHead)
+                   || userRoles.Contains(Roles.CityHeadDeputy)
+                   || userRoles.Contains(Roles.CityReferentUPS)
+                   || userRoles.Contains(Roles.CityReferentUSP)
+                   || userRoles.Contains(Roles.CityReferentOfActiveMembership); ;
+        }
+        private bool IsUserAdmin(IList<string> userRoles)
+        {
+            return userRoles.Contains(Roles.Admin) || userRoles.Contains(Roles.GoverningBodyAdmin);
         }
     }
 }

--- a/EPlast/EPlast.BLL/Services/UserProfiles/UserProfileAccessService.cs
+++ b/EPlast/EPlast.BLL/Services/UserProfiles/UserProfileAccessService.cs
@@ -33,10 +33,10 @@ namespace EPlast.BLL.Services.UserProfiles
             return role switch
             {
                 Roles.CityHead =>
-                    (currentUserRoles.Contains(Roles.CityHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City)) ||
-                    (currentUserRoles.Contains(Roles.OkrugaHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Region)),
+                    currentUserRoles.Contains(Roles.CityHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City) ||
+                    currentUserRoles.Contains(Roles.OkrugaHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Region),
                 Roles.KurinHead =>
-                    (currentUserRoles.Contains(Roles.KurinHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club)),
+                    currentUserRoles.Contains(Roles.KurinHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club),
                 _ => false,
             };
         }
@@ -56,9 +56,9 @@ namespace EPlast.BLL.Services.UserProfiles
                 return true;
             }
             return
-                ((currentUserRoles.Contains(Roles.OkrugaHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Region)) ||
-                ((currentUserRoles.Contains(Roles.CityHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City)) ||
-                ((currentUserRoles.Contains(Roles.KurinHead)) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club));
+                currentUserRoles.Contains(Roles.OkrugaHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Region) ||
+                currentUserRoles.Contains(Roles.CityHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.City) ||
+                currentUserRoles.Contains(Roles.KurinHead) && await _userService.IsUserInSameCellAsync(currentUser, focusUser, CellType.Club);
         }
 
         public async Task<bool> CanViewFullProfile(User user, string focusUserId)
@@ -111,7 +111,7 @@ namespace EPlast.BLL.Services.UserProfiles
                    || userRoles.Contains(Roles.CityHeadDeputy)
                    || userRoles.Contains(Roles.CityReferentUPS)
                    || userRoles.Contains(Roles.CityReferentUSP)
-                   || userRoles.Contains(Roles.CityReferentOfActiveMembership); ;
+                   || userRoles.Contains(Roles.CityReferentOfActiveMembership);
         }
         private bool IsUserAdmin(IList<string> userRoles)
         {

--- a/EPlast/EPlast.Tests/Controllers/AnnualReportControllerTests.cs
+++ b/EPlast/EPlast.Tests/Controllers/AnnualReportControllerTests.cs
@@ -28,7 +28,6 @@ namespace EPlast.Tests.Controllers
     {
         private readonly Mock<IAnnualReportService> _annualReportService;
         private readonly Mock<IClubAnnualReportService> _clubAnnualReportService;
-        private readonly Mock<IStringLocalizer<AnnualReportControllerMessage>> _localizer;
         private readonly Mock<ILoggerService<AnnualReportController>> _loggerService;
         private readonly Mock<IMapper> _mapper;
         private readonly Mock<UserManager<User>> _userManager;

--- a/EPlast/EPlast.Tests/Services/UserProfiles/UserProfileAccessServiceTests.cs
+++ b/EPlast/EPlast.Tests/Services/UserProfiles/UserProfileAccessServiceTests.cs
@@ -72,19 +72,6 @@ namespace EPlast.Tests.Services.UserProfiles
         public async Task ViewFullProfile_SameUser_ReturnsTrue()
         {
             //Arrange
-            _mockUserManager.Setup(u => u.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { });
-
-            //Act
-            var result = await _userProfileAccessService.CanViewFullProfile(_fakeUser, _fakeUser.Id);
-
-            //Assert
-            Assert.IsTrue(result);
-        }
-
-        [Test]
-        public async Task ViewFullProfile_SameUser_ReturnsTrue()
-        {
-            //Arrange
 
             //Act
             var result = await _userProfileAccessService.CanViewFullProfile(_fakeUser, _fakeUser.Id);
@@ -138,7 +125,7 @@ namespace EPlast.Tests.Services.UserProfiles
         public async Task ViewFullProfile_SameCity_ReturnsTrue()
         {
             //Arrange
-            _mockUserManager.Setup(u => u.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.CityHead });
+            _mockUserManager.Setup(u => u.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.PlastMember });
             _mockUserService.Setup(u => u.IsUserSameCity(It.IsAny<UserDto>(), It.IsAny<UserDto>())).Returns(true);
 
             //Act
@@ -152,7 +139,7 @@ namespace EPlast.Tests.Services.UserProfiles
         public async Task ViewFullProfile_SameClub_ReturnsTrue()
         {
             //Arrange
-            _mockUserManager.Setup(u => u.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.CityHead });
+            _mockUserManager.Setup(u => u.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.PlastMember });
             _mockUserService.Setup(u => u.IsUserSameClub(It.IsAny<UserDto>(), It.IsAny<UserDto>())).Returns(true);
 
             //Act
@@ -186,6 +173,33 @@ namespace EPlast.Tests.Services.UserProfiles
 
             //Assert
             Assert.IsFalse(result);
+        }
+
+        [Test]
+        public async Task ViewFullProfile_AsAnyOtherRoleAndFromOtherPlace_ReturnsFalse()
+        {
+            //Arrange
+            _mockUserManager.Setup(u => u.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { Roles.PlastMember });
+            _mockUserService.Setup(u => u.IsUserSameCity(It.IsAny<UserDto>(), It.IsAny<UserDto>())).Returns(false);
+            _mockUserService.Setup(u => u.IsUserSameClub(It.IsAny<UserDto>(), It.IsAny<UserDto>())).Returns(false);
+
+            //Act
+            var result = await _userProfileAccessService.CanViewFullProfile(_fakeUser, It.IsAny<string>());
+
+            //Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public async Task EditUserProfile_SameUser_ReturnsTrue()
+        {
+            //Arrange
+            
+            //Act
+            var result = await _userProfileAccessService.CanEditUserProfile(_fakeUser, _fakeUser.Id);
+
+            //Assert
+            Assert.IsTrue(result);
         }
 
         [Test]

--- a/EPlast/EPlast.Tests/Services/UserProfiles/UserProfileAccessServiceTests.cs
+++ b/EPlast/EPlast.Tests/Services/UserProfiles/UserProfileAccessServiceTests.cs
@@ -82,6 +82,18 @@ namespace EPlast.Tests.Services.UserProfiles
         }
 
         [Test]
+        public async Task ViewFullProfile_SameUser_ReturnsTrue()
+        {
+            //Arrange
+
+            //Act
+            var result = await _userProfileAccessService.CanViewFullProfile(_fakeUser, _fakeUser.Id);
+
+            //Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
         public async Task ViewFullProfile_AsAdmin_ReturnsTrue()
         {
             //Arrange


### PR DESCRIPTION
Due to a merge conflict someone overwrote important logic in user profile access, this pull request should fix that. 

This pull request is based on https://github.com/ita-social-projects/EPlast/commit/de456a8a8519abc16fcb95d4cd09671c1ea7a183
