### PR TITLE
Fix-#2320. Removed ability for editing annual report of other regions as Region admin using Postman/Swagger

### DIFF
--- a/EPlast/EPlast.BLL/Interfaces/Region/IRegionAnnualReportService.cs
+++ b/EPlast/EPlast.BLL/Interfaces/Region/IRegionAnnualReportService.cs
@@ -118,7 +118,7 @@ namespace EPlast.BLL.Interfaces.Region
         /// <response code="403">User hasn't access to region annual report</response>
         /// <response code="404">Region annual report does not exist</response>
         /// <response code="404">Region annual report model is not valid</response>
-        Task EditAsync(int reportId, RegionAnnualReportQuestions regionAnnualReportQuestions);
+        Task EditAsync(User user, int reportId, RegionAnnualReportQuestions regionAnnualReportQuestions);
 
         Task UpdateMembersInfo(int regionId, int year);
 

--- a/EPlast/EPlast.BLL/Services/Region/RegionAnnualReportService.cs
+++ b/EPlast/EPlast.BLL/Services/Region/RegionAnnualReportService.cs
@@ -266,8 +266,14 @@ namespace EPlast.BLL.Services.Region
         }
 
         ///<inheritdoc/>
-        public async Task EditAsync(int reportId, RegionAnnualReportQuestions regionAnnualReportQuestions)
+        public async Task EditAsync(User user, int reportId, RegionAnnualReportQuestions regionAnnualReportQuestions)
         {
+            var report = await _repositoryWrapper.RegionAnnualReports.GetFirstOrDefaultAsync(r => r.ID == reportId);
+
+            if (!await _regionAccessService.HasAccessAsync(user, report.RegionId))
+            {
+                throw new UnauthorizedAccessException();
+            }
             var regionAnnualReport = await _repositoryWrapper.RegionAnnualReports.GetFirstOrDefaultAsync(
                 predicate: a => a.ID == reportId && a.Status == AnnualReportStatus.Unconfirmed);
             if (regionAnnualReport.Status != AnnualReportStatus.Unconfirmed)

--- a/EPlast/EPlast.Tests/Controllers/RegionsControllerTests.cs
+++ b/EPlast/EPlast.Tests/Controllers/RegionsControllerTests.cs
@@ -1083,7 +1083,7 @@ namespace EPlast.Tests.Controllers
         {
             // Arrange
             int reportID = 0;
-            _regionAnnualReportService.Setup(x => x.EditAsync(reportID, It.IsAny<RegionAnnualReportQuestions>())).Throws<NullReferenceException>();
+            _regionAnnualReportService.Setup(x => x.EditAsync(It.IsAny<User>(), reportID, It.IsAny<RegionAnnualReportQuestions>())).Throws<NullReferenceException>();
 
             // Act
             var result = await _regionController.EditRegionReport(reportID, null);

--- a/EPlast/EPlast.Tests/Controllers/RegionsControllerTests.cs
+++ b/EPlast/EPlast.Tests/Controllers/RegionsControllerTests.cs
@@ -1110,7 +1110,7 @@ namespace EPlast.Tests.Controllers
             // Arrange
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User());
 
-            _regionAnnualReportService.Setup(x => x.EditAsync(It.IsAny<int>(), It.IsAny<RegionAnnualReportQuestions>()));
+            _regionAnnualReportService.Setup(x => x.EditAsync(It.IsAny<User>(), It.IsAny<int>(), It.IsAny<RegionAnnualReportQuestions>()));
             int reportID = 1;
 
             // Act
@@ -1130,7 +1130,7 @@ namespace EPlast.Tests.Controllers
             _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User());
             _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { "Admin" });
 
-            _regionAnnualReportService.Setup(x => x.EditAsync(It.IsAny<int>(), It.IsAny<RegionAnnualReportQuestions>()))
+            _regionAnnualReportService.Setup(x => x.EditAsync(It.IsAny<User>(), It.IsAny<int>(), It.IsAny<RegionAnnualReportQuestions>()))
                 .ThrowsAsync(new InvalidOperationException());
 
             int reportID = 1;
@@ -1142,6 +1142,28 @@ namespace EPlast.Tests.Controllers
             Assert.IsNotNull(result);
             Assert.AreEqual(400, ((ObjectResult)result).StatusCode);
             Assert.AreEqual("{ message = Виникла помилка при внесенні змін до річного звіту округи }", ((ObjectResult)result).Value.ToString());
+        }
+
+        [Test]
+        public async Task EditRegionReport_Unauthorized()
+        {
+            // Arrange
+            _userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new User());
+            _userManager.Setup(x => x.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>() { "Голова Округи" });
+            _regionAnnualReportService.Setup(x => x.EditAsync(It.IsAny<User>(), It.IsAny<int>(),
+                It.IsAny<RegionAnnualReportQuestions>()))
+                .ThrowsAsync(new UnauthorizedAccessException());
+
+            int reportId = 1;
+
+            // Act
+            var result = await _regionController.EditRegionReport(reportId, fakeRegionAnnualReportQuestions());
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(403, ((ObjectResult)result).StatusCode);
+            Assert.AreEqual("{ message = Користувач не має права редагувати річний звіт }", 
+                ((ObjectResult)result).Value.ToString());
         }
 
         [Test]

--- a/EPlast/EPlast.Tests/Services/Regions/RegionAnnualReportServiceTest.cs
+++ b/EPlast/EPlast.Tests/Services/Regions/RegionAnnualReportServiceTest.cs
@@ -151,10 +151,10 @@ namespace EPlast.Tests.Services.Regions
             _mockRepositoryWrapper.Setup(x => x.RegionAnnualReports.GetRegionMembersInfoAsync(It.IsAny<int>(),
                     It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync(new List<RegionMembersInfoTableObject>() { _fakeMembersInfoTableObject() });
-
+            _mockRegionAccessService.Setup(x => x.HasAccessAsync(It.IsAny<User>(), It.IsAny<int>())).ReturnsAsync(true);
 
             //Act
-            await _service.EditAsync(1, _fakeRegionAnnualReportQuestions());
+            await _service.EditAsync(new User(), 1, _fakeRegionAnnualReportQuestions());
 
             //Assert
             _mockRepositoryWrapper.Verify(x => x.RegionAnnualReports.GetFirstOrDefaultAsync(
@@ -171,10 +171,11 @@ namespace EPlast.Tests.Services.Regions
             _mockRepositoryWrapper.Setup(x => x.RegionAnnualReports.GetRegionMembersInfoAsync(It.IsAny<int>(),
                     It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync(new List<RegionMembersInfoTableObject>() { _fakeMembersInfoTableObject() });
+            _mockRegionAccessService.Setup(x => x.HasAccessAsync(It.IsAny<User>(), It.IsAny<int>())).ReturnsAsync(true);
 
             // Act & Assert
             Assert.ThrowsAsync<InvalidOperationException>(() =>
-                _service.EditAsync(1, _fakeRegionAnnualReportQuestions()));
+                _service.EditAsync(new User(), 1, _fakeRegionAnnualReportQuestions()));
         }
 
         [Test]
@@ -347,16 +348,31 @@ namespace EPlast.Tests.Services.Regions
         }
 
         [Test]
-        public void EditAsync_ThrowsException()
+        public void EditAsync_ThrowsInvalidOperationException()
         {
             //Arrange
             _mockRepositoryWrapper.Setup(x => x.RegionAnnualReports.GetFirstOrDefaultAsync(
                     It.IsAny<Expression<Func<DataAccess.Entities.RegionAnnualReport, bool>>>(), null))
                 .ReturnsAsync(new RegionAnnualReport() { RegionId = 1, Status = AnnualReportStatus.Confirmed });
+            _mockRegionAccessService.Setup(x => x.HasAccessAsync(It.IsAny<User>(), It.IsAny<int>())).ReturnsAsync(true);
 
             //Assert
             Assert.ThrowsAsync<InvalidOperationException>(() =>
-                _service.EditAsync(1, _fakeRegionAnnualReportQuestions()));
+                _service.EditAsync(new User(), 1, _fakeRegionAnnualReportQuestions()));
+        }
+
+        [Test]
+        public void EditAsync_ThrowsUnauthorizedExeption()
+        {
+            //Arrange
+            _mockRepositoryWrapper.Setup(x => x.RegionAnnualReports.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<DataAccess.Entities.RegionAnnualReport, bool>>>(), null))
+                .ReturnsAsync(new RegionAnnualReport() { RegionId = 1, Status = AnnualReportStatus.Confirmed });
+            _mockRegionAccessService.Setup(x => x.HasAccessAsync(It.IsAny<User>(), It.IsAny<int>())).ReturnsAsync(false);
+
+            //Assert
+            Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+                _service.EditAsync(new User(), 1, _fakeRegionAnnualReportQuestions()));
         }
 
         private RegionMembersInfoTableObject _fakeMembersInfoTableObject()

--- a/EPlast/EPlast.WebApi/Controllers/RegionsController.cs
+++ b/EPlast/EPlast.WebApi/Controllers/RegionsController.cs
@@ -278,7 +278,6 @@ namespace EPlast.WebApi.Controllers
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    _logger.LogError($"Annual report (id: {reportId}) can not be edited");
                     return StatusCode(StatusCodes.Status403Forbidden, new { message = "Користувач не має права редагувати річний звіт" });
                 }
             }

--- a/EPlast/EPlast.WebApi/Controllers/RegionsController.cs
+++ b/EPlast/EPlast.WebApi/Controllers/RegionsController.cs
@@ -270,7 +270,7 @@ namespace EPlast.WebApi.Controllers
             {
                 try
                 {
-                    await _regionAnnualReportService.EditAsync(reportId, regionAnnualReportQuestions);
+                    await _regionAnnualReportService.EditAsync(await _userManager.GetUserAsync(User), reportId, regionAnnualReportQuestions);
                     _logger.LogInformation($"User (id: {(await _userManager.GetUserAsync(User)).Id}) edited annual report (id: {reportId})");
                     return StatusCode(StatusCodes.Status200OK, new { message = "Річний звіт округи змінено" });
                 }
@@ -283,6 +283,11 @@ namespace EPlast.WebApi.Controllers
                 {
                     _logger.LogError($"Annual report (id: {reportId}) not found");
                     return StatusCode(StatusCodes.Status404NotFound, new { message = "Річний звіт округи не знайдено" });
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    _logger.LogError($"Annual report (id: {reportId}) can not be edited");
+                    return StatusCode(StatusCodes.Status403Forbidden, new { message = "Користувач не має права редагувати річний звіт" });
                 }
             }
             return BadRequest(ModelState);


### PR DESCRIPTION
closes https://github.com/ita-social-projects/EPlast/issues/2320